### PR TITLE
[Feat] DIContainer와 Mock Repository를 구현하여 의존성 주입 및 UI 개발 기반을 마련합니다.

### DIFF
--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		BC7343082E4B62F500A24ADE /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343072E4B62EF00A24ADE /* NetworkService.swift */; };
 		BC73430A2E4B635400A24ADE /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343092E4B634900A24ADE /* NetworkError.swift */; };
 		BC7343152E4B7B6A00A24ADE /* APIConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343142E4B7B6300A24ADE /* APIConstant.swift */; };
+		BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343222E4C0CEF00A24ADE /* DIContainer.swift */; };
+		BC7343252E4C120C00A24ADE /* MockProductRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343242E4C120300A24ADE /* MockProductRepository.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +66,8 @@
 		BC7343072E4B62EF00A24ADE /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		BC7343092E4B634900A24ADE /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		BC7343142E4B7B6300A24ADE /* APIConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstant.swift; sourceTree = "<group>"; };
+		BC7343222E4C0CEF00A24ADE /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
+		BC7343242E4C120300A24ADE /* MockProductRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductRepository.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -130,6 +134,7 @@
 		BC7342CC2E4AF90300A24ADE /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				BC7343222E4C0CEF00A24ADE /* DIContainer.swift */,
 				BC7342BA2E4AE5EF00A24ADE /* AppDelegate.swift */,
 				BC7342BD2E4AE5EF00A24ADE /* SceneDelegate.swift */,
 				BC7342BE2E4AE5EF00A24ADE /* ViewController.swift */,
@@ -290,6 +295,7 @@
 		BC7342DF2E4AF9CF00A24ADE /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				BC7343242E4C120300A24ADE /* MockProductRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -518,7 +524,9 @@
 				BC7343082E4B62F500A24ADE /* NetworkService.swift in Sources */,
 				BC7343062E4B608C00A24ADE /* ProductAPI.swift in Sources */,
 				BC7342EA2E4B479300A24ADE /* ProductRepositoryProtocol.swift in Sources */,
+				BC7343252E4C120C00A24ADE /* MockProductRepository.swift in Sources */,
 				BC7342C02E4AE5EF00A24ADE /* ViewController.swift in Sources */,
+				BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */,
 				BC7342C12E4AE5EF00A24ADE /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CaloLink/Source/Application/DIContainer.swift
+++ b/CaloLink/Source/Application/DIContainer.swift
@@ -1,0 +1,56 @@
+//
+//  DIContainer.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import Foundation
+
+// MARK: - DIContainer
+// 앱의 모든 의존성을 생성하고 관리하는 중앙 컨테이너
+final class DIContainer {
+    // MARK: - 부품 창고 (Singleton Instances)
+
+    // Services: 네트워크 통신 엔진은 앱 전체에서 하나만 존재
+    lazy var networkService: NetworkServiceProtocol = DefaultNetworkService()
+
+    // Repositories: 데이터 저장소도 하나만 존재
+    lazy var productRepository: ProductRepositoryProtocol = MockProductRepository()
+//    lazy var productRepository: ProductRepositoryProtocol = DefaultProductRepository(networkService: networkService)
+
+    // Use Cases: UseCase는 상태를 가지지 않으므로 하나만 만들어 재사용
+    lazy var searchProductsUseCase: SearchProductsUseCaseProtocol = SearchProductsUseCase(productRepository: productRepository)
+    lazy var getProductDetailUseCase: GetProductDetailUseCaseProtocol = GetProductDetailUseCase(productRepository: productRepository)
+
+/*
+    // MARK: - 조립 라인 (Factory Methods)
+
+    // MARK: - 검색 결과 목록 Scene
+    // ListViewModel을 생성하는 팩토리 메서드
+    func makeListViewModel() -> ListViewModel {
+        // 부품 창고에서 "searchProductsUseCase"를 가져와 주입
+        return ListViewModel(searchProductsUseCase: searchProductsUseCase)
+    }
+
+    // ListViewController를 생성하는 팩토리 메서드
+    func makeListViewController() -> ListViewController {
+        // "makeListViewModel" 조립 라인을 호출하여 새로운 ViewModel을 만들고 주입
+        return ListViewController(viewModel: makeListViewModel())
+    }
+
+    // MARK: - 상품 상세 Scene
+    // DetailViewModel을 생성하는 팩토리 메서드
+    func makeDetailViewModel(productId: String) -> DetailViewModel {
+        return DetailViewModel(
+            productId: productId,
+            getProductDetailUseCase: getProductDetailUseCase
+        )
+    }
+
+    // DetailViewController를 생성하는 팩토리 메서드
+    func makeDetailViewController(productId: String) -> DetailViewController {
+        return DetailViewController(viewModel: makeDetailViewModel(productId: productId))
+    }
+*/
+}

--- a/CaloLink/Source/Data/Repository/MockProductRepository.swift
+++ b/CaloLink/Source/Data/Repository/MockProductRepository.swift
@@ -1,0 +1,92 @@
+//
+//  MockProductRepository.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import Foundation
+
+// MARK: - MockProductRepository
+// 테스트를 위해 실제 네트워크 통신 없이 가짜 데이터를 반환하는 Repository
+final class MockProductRepository: ProductRepositoryProtocol {
+    // MARK: - 상품 목록 가져오기 (가짜 데이터)
+    func fetchProducts(
+        query: SearchQuery,
+        completion: @escaping (Result<[Product], Error>) -> Void
+    ) {
+        // 실제 네트워크 통신처럼 보이도록 0.5초의 딜레이를 부여
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let mockProducts: [Product] = [
+                Product(
+                    id: "P001",
+                    name: "맛있는 닭가슴살 100g (검색어: \(query.searchText))",
+                    imageURL: URL(string: "https://example.com/images/chicken_breast.jpg"),
+                    price: 2500,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "25g"),
+                        KeyNutrient(name: "칼로리", value: "130kcal")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P003",
+                    name: "저염 현미밥 도시락",
+                    imageURL: URL(string: "https://example.com/images/rice_box.jpg"),
+                    price: 4500,
+                    keyNutrients: [
+                        KeyNutrient(name: "나트륨", value: "250mg"),
+                        KeyNutrient(name: "탄수화물", value: "50g")
+                    ]
+                )
+            ]
+
+            // 성공적으로 가짜 데이터를 반환
+            completion(.success(mockProducts))
+        }
+    }
+
+    // MARK: - 상품 상세 정보 가져오기 (가짜 데이터)
+    func fetchProductDetail(
+        productId: String,
+        completion: @escaping (Result<ProductDetail, Error>) -> Void
+    ) {
+        // 실제 네트워크 통신처럼 보이도록 0.5초의 딜레이를 부여
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let mockDetail = ProductDetail(
+                id: productId,
+                name: "맛있는 닭가슴살 100g (상세)",
+                imageURL: URL(string: "https://example.com/images/chicken_breast.jpg"),
+                nutritionInfo: NutritionInfo(
+                    totalSize: 100,
+                    calories: 130,
+                    sodium: NutrientValue(amount: 300, unit: "mg", percentage: 15),
+                    carbs: NutrientValue(amount: 2, unit: "g", percentage: 1),
+                    sugars: NutrientValue(amount: 1, unit: "g", percentage: nil),
+                    fat: NutrientValue(amount: 3, unit: "g", percentage: 4),
+                    transFat: NutrientValue(amount: 0, unit: "g", percentage: 0),
+                    saturatedFat: NutrientValue(amount: 1, unit: "g", percentage: 5),
+                    cholesterol: NutrientValue(amount: 80, unit: "mg", percentage: 27),
+                    protein: NutrientValue(amount: 25, unit: "g", percentage: 50)
+                ),
+                shopLinks: [
+                    ShopLink(mallName: "쿠팡", price: 2500, linkURL: URL(string: "https://coupang.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "마켓컬리", price: 2600, linkURL: URL(string: "https://kurly.com"))
+                ]
+            )
+
+            // 성공적으로 가짜 데이터를 반환
+            completion(.success(mockDetail))
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목은 "OO을 해서 OO가 됩니다.", "OO화면의 UI를 구현합니다." 로 올려주세요 -->

# 개요
<!-- 개요는 와이어프레임이나, 이슈등을 사용하여 작업의 시작점을 알려줍니다. -->
- #9 
- 실제 UI를 구현하기 전 의존성 주입 시스템을 구축하고 가짜 데이터를 제공할 Mock Repository를 구현합니다.
- 백엔드 API 없이도 독립적으로 진행할 수 있는 기반을 마련합니다.

# 작업 내용
<!-- 작업 내용에는 "무엇"은 간단하게 적고, 왜 이렇게 작성했는지 위주로 적습니다. -->
<!-- UI 구현의 경우 가능한 스크린샷을 포함합니다. -->
- DIContainer 구현
  - 앱에 필요한 모든 객체(Repository, UseCase, ViewModel 등)를 생성하고 관리하는 DIContainer를 팩토리 패턴으로 구현했습니다.
  - 각 객체가 필요로 하는 의존성을 명시적으로 주입하여 코드의 결합도를 낮추고, 컴파일 타임에 의존성 관련 에러를 발견할 수 있도록 설계했습니다.

- MockProductRepository 구현
  - `ProductRepositoryProtocol`을 준수하는 `MockProductRepository`를 구현했습니다.
  - 실제 네트워크 통신 없이도 UI 개발에 필요한 `[Product]` 및 `ProductDetail` 샘플 데이터를 반환하는 "가짜 서버" 역할을 합니다. 이를 통해 다음 단계에서 해볼 UI 구현을 원활하게 진행할 수 있습니다.

# 기타
<!-- 기타 얘기할 사항이 있으면 얘기합니다. -->
- 현재 UI 코드를 포함하지 않으며 아키텍처의 기반을 다지는데 집중했습니다.
- 다음 단계에서는 `DIContainer`와 `MockProdutRepository`를 사용하여 UI를 개발할 예정입니다.
