### PR TITLE
[Feat] 상세화면의 UI를 구현합니다.

### DIFF
--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		BC7343152E4B7B6A00A24ADE /* APIConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343142E4B7B6300A24ADE /* APIConstant.swift */; };
 		BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343222E4C0CEF00A24ADE /* DIContainer.swift */; };
 		BC7343252E4C120C00A24ADE /* MockProductRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343242E4C120300A24ADE /* MockProductRepository.swift */; };
+		BC7343332E4C2D1600A24ADE /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343322E4C2D0F00A24ADE /* DetailViewController.swift */; };
+		BC7343352E4C2D9300A24ADE /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343342E4C2D9000A24ADE /* DetailViewModel.swift */; };
+		BC7343372E4C2DA400A24ADE /* ProductNutritionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343362E4C2D9B00A24ADE /* ProductNutritionView.swift */; };
+		BC73433A2E4C2DAE00A24ADE /* ProductPriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343392E4C2DAB00A24ADE /* ProductPriceView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +72,10 @@
 		BC7343142E4B7B6300A24ADE /* APIConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstant.swift; sourceTree = "<group>"; };
 		BC7343222E4C0CEF00A24ADE /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
 		BC7343242E4C120300A24ADE /* MockProductRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductRepository.swift; sourceTree = "<group>"; };
+		BC7343322E4C2D0F00A24ADE /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		BC7343342E4C2D9000A24ADE /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
+		BC7343362E4C2D9B00A24ADE /* ProductNutritionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNutritionView.swift; sourceTree = "<group>"; };
+		BC7343392E4C2DAB00A24ADE /* ProductPriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceView.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -253,6 +261,7 @@
 		BC7342DA2E4AF99D00A24ADE /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				BC7343342E4C2D9000A24ADE /* DetailViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -260,6 +269,9 @@
 		BC7342DB2E4AF9A100A24ADE /* View */ = {
 			isa = PBXGroup;
 			children = (
+				BC7343392E4C2DAB00A24ADE /* ProductPriceView.swift */,
+				BC7343362E4C2D9B00A24ADE /* ProductNutritionView.swift */,
+				BC7343322E4C2D0F00A24ADE /* DetailViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -516,6 +528,8 @@
 				BC7343012E4B5BC100A24ADE /* Endpoint.swift in Sources */,
 				BC7342BF2E4AE5EF00A24ADE /* SceneDelegate.swift in Sources */,
 				BC7342E42E4B427900A24ADE /* ProductDetail.swift in Sources */,
+				BC7343372E4C2DA400A24ADE /* ProductNutritionView.swift in Sources */,
+				BC7343332E4C2D1600A24ADE /* DetailViewController.swift in Sources */,
 				BC7342E22E4B3EA300A24ADE /* Product.swift in Sources */,
 				BC7342FD2E4B56C800A24ADE /* ProductListResponseDTO.swift in Sources */,
 				BC7342EC2E4B4D4600A24ADE /* SearchProductsUseCase.swift in Sources */,
@@ -523,7 +537,9 @@
 				BC7343152E4B7B6A00A24ADE /* APIConstant.swift in Sources */,
 				BC7343082E4B62F500A24ADE /* NetworkService.swift in Sources */,
 				BC7343062E4B608C00A24ADE /* ProductAPI.swift in Sources */,
+				BC73433A2E4C2DAE00A24ADE /* ProductPriceView.swift in Sources */,
 				BC7342EA2E4B479300A24ADE /* ProductRepositoryProtocol.swift in Sources */,
+				BC7343352E4C2D9300A24ADE /* DetailViewModel.swift in Sources */,
 				BC7343252E4C120C00A24ADE /* MockProductRepository.swift in Sources */,
 				BC7342C02E4AE5EF00A24ADE /* ViewController.swift in Sources */,
 				BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */,

--- a/CaloLink/Source/Application/DIContainer.swift
+++ b/CaloLink/Source/Application/DIContainer.swift
@@ -38,7 +38,7 @@ final class DIContainer {
         // "makeListViewModel" 조립 라인을 호출하여 새로운 ViewModel을 만들고 주입
         return ListViewController(viewModel: makeListViewModel())
     }
-
+ */
     // MARK: - 상품 상세 Scene
     // DetailViewModel을 생성하는 팩토리 메서드
     func makeDetailViewModel(productId: String) -> DetailViewModel {
@@ -52,5 +52,4 @@ final class DIContainer {
     func makeDetailViewController(productId: String) -> DetailViewController {
         return DetailViewController(viewModel: makeDetailViewModel(productId: productId))
     }
-*/
 }

--- a/CaloLink/Source/Application/SceneDelegate.swift
+++ b/CaloLink/Source/Application/SceneDelegate.swift
@@ -15,8 +15,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
+        let diContainer = DIContainer()
+
+        // 검증을 위해 임시로 사용
+        // 인스턴스를 통해 팩토리 메서드를 호출하고 테스트할 상품의 ID를 전달
+        // MockRepository에 있는 ID 중 하나인 "P001"을 사용
+        let detailViewController = diContainer.makeDetailViewController(productId: "P001")
+
+        let navigationController = UINavigationController(rootViewController: detailViewController)
+
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = ViewController()
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
 

--- a/CaloLink/Source/Data/Repository/MockProductRepository.swift
+++ b/CaloLink/Source/Data/Repository/MockProductRepository.swift
@@ -81,7 +81,16 @@ final class MockProductRepository: ProductRepositoryProtocol {
                 shopLinks: [
                     ShopLink(mallName: "쿠팡", price: 2500, linkURL: URL(string: "https://coupang.com")),
                     ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
-                    ShopLink(mallName: "마켓컬리", price: 2600, linkURL: URL(string: "https://kurly.com"))
+                    ShopLink(mallName: "마켓컬리", price: 2600, linkURL: URL(string: "https://kurly.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com")),
+                    ShopLink(mallName: "네이버쇼핑", price: 2400, linkURL: URL(string: "https://shopping.naver.com"))
                 ]
             )
 

--- a/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
+++ b/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
@@ -1,0 +1,184 @@
+//
+//  DetailViewController.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import UIKit
+
+// MARK: - DetailViewController
+final class DetailViewController: UIViewController {
+
+    // MARK: - Properties
+    private let viewModel: DetailViewModel
+
+    // MARK: - UI Components
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private let productImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .systemGray5 // 이미지가 없을 때 배경색
+        imageView.tintColor = .systemGray3
+        return imageView
+    }()
+
+    private let productNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 22)
+        label.textColor = .black
+        label.numberOfLines = 2
+        return label
+    }()
+
+    private let productInfoSegmentedControl: UISegmentedControl = {
+        let segmentedControl = UISegmentedControl(items: ["영양성분", "가격비교"])
+        segmentedControl.selectedSegmentIndex = 0
+        return segmentedControl
+    }()
+
+    private let productNutritionView = ProductNutritionView()
+    private let productPriceView = ProductPriceView()
+
+    // MARK: - Initializer
+    init(viewModel: DetailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        bindViewModel()
+        viewModel.viewDidLoad() // ViewModel에 화면이 로드되었음을 알림
+    }
+}
+
+// MARK: - Private Methods
+private extension DetailViewController {
+    // UI 레이아웃 및 초기 설정을 담당합니다.
+    func setupUI() {
+        view.backgroundColor = .white
+
+        productInfoSegmentedControl.addTarget(
+            self,
+            action: #selector(segmentedControlChanged),
+            for: .valueChanged
+        )
+
+        [
+            productImageView,
+            productNameLabel,
+            productInfoSegmentedControl,
+            productNutritionView,
+            productPriceView,
+            activityIndicator
+        ].forEach {
+            view.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        NSLayoutConstraint.activate([
+            productImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            productImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            productImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            productImageView.heightAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.7),
+
+            productNameLabel.topAnchor.constraint(equalTo: productImageView.bottomAnchor, constant: 16),
+            productNameLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            productNameLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+
+            productInfoSegmentedControl.topAnchor.constraint(equalTo: productNameLabel.bottomAnchor, constant: 16),
+            productInfoSegmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
+            productInfoSegmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+            productInfoSegmentedControl.heightAnchor.constraint(equalToConstant: 40),
+
+            productNutritionView.topAnchor.constraint(equalTo: productInfoSegmentedControl.bottomAnchor),
+            productNutritionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            productNutritionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            productNutritionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+
+            productPriceView.topAnchor.constraint(equalTo: productInfoSegmentedControl.bottomAnchor),
+            productPriceView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            productPriceView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            productPriceView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+
+        // 초기 탭 상태 설정
+        updateSegmentedContentView()
+    }
+
+    // Segmented Control의 선택이 변경될 때 호출됨
+    @objc func segmentedControlChanged(_ sender: UISegmentedControl) {
+        updateSegmentedContentView()
+    }
+
+    // Segmented Control의 선택에 따라 올바른 뷰를 보여줌
+    func updateSegmentedContentView() {
+        let isNutritionSelected = productInfoSegmentedControl.selectedSegmentIndex == 0
+        productNutritionView.isHidden = !isNutritionSelected
+        productPriceView.isHidden = isNutritionSelected
+    }
+
+    // ViewModel의 상태 변화를 구독하고 UI를 업데이트
+    func bindViewModel() {
+        viewModel.onUpdate = { [weak self] in
+            guard let self = self else { return }
+
+            if self.viewModel.isLoading {
+                self.activityIndicator.startAnimating()
+            } else {
+                self.activityIndicator.stopAnimating()
+            }
+            
+            // ViewModel의 상태가 변경되면 UI를 업데이트
+            self.updateUI()
+        }
+    }
+
+    // ViewModel로부터 받은 데이터로 UI 컴포넌트를 채움
+    func updateUI() {
+        productNameLabel.text = viewModel.productName
+
+        let placeholderImage = UIImage(
+            systemName: "photo",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 50, weight: .light)
+        )
+
+        // TODO: - 비동기, 이미지 로드 개선
+        if let imageURL = viewModel.imageURL {
+            DispatchQueue.global().async {
+                if let data = try? Data(contentsOf: imageURL), let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self.productImageView.image = image
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        self.productImageView.image = placeholderImage
+                    }
+                }
+            }
+        } else {
+            productImageView.image = placeholderImage
+        }
+
+        // ViewModel의 가공된 프로퍼티를 사용
+        if let nutritionInfo = viewModel.nutritionInfo {
+            productNutritionView.updateNutritionInfo(with: nutritionInfo)
+        }
+        productPriceView.updateShopLinks(with: viewModel.sortedShopLinks)    }
+}

--- a/CaloLink/Source/Presentation/DetailScene/View/ProductNutritionView.swift
+++ b/CaloLink/Source/Presentation/DetailScene/View/ProductNutritionView.swift
@@ -1,0 +1,167 @@
+//
+//  ProductNutritionView.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import UIKit
+
+// MARK: - ProductNutritionView
+final class ProductNutritionView: UIView {
+    // MARK: - UI Components
+    private let totalAmountLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 18)
+        label.textColor = .darkGray
+        return label
+    }()
+
+    private let kcalLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 25)
+        label.textColor = .black
+        return label
+    }()
+
+    private let percentInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "1일 영양성분 기준치에 대한 비율"
+        label.font = UIFont.systemFont(ofSize: 15)
+        label.textColor = .gray
+        return label
+    }()
+
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .lightGray.withAlphaComponent(0.5)
+        return view
+    }()
+
+    private let nutritionStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 5
+        return stackView
+    }()
+
+    private let footnoteLabel: UILabel = {
+        let label = UILabel()
+        label.text = "※ 1일 영양성분 기준치에 대한 비율(%)은 2,000kcal 기준이므로 개인의 필요 열량에 따라 다를 수 있습니다."
+        label.font = UIFont.systemFont(ofSize: 12)
+        label.textColor = .gray
+        label.numberOfLines = 0
+        return label
+    }()
+
+    // MARK: - Initializer
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public 메서드
+    // ViewModel로부터 받은 데이터로 View를 업데이트
+    public func updateNutritionInfo(with nutritionInfo: NutritionInfo) {
+        if let totalSize = nutritionInfo.totalSize {
+            totalAmountLabel.text = "총 내용량 \(totalSize)g"
+        } else {
+            totalAmountLabel.text = "총 내용량 - g"
+        }
+
+        if let calories = nutritionInfo.calories {
+            kcalLabel.text = "\(calories)kcal"
+        } else {
+            kcalLabel.text = "- kcal"
+        }
+
+        // 기존에 있던 영양성분 뷰들을 모두 제거
+        nutritionStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        // 새로운 데이터로 영양성분 뷰들을 다시 만듦
+        addNutritionRow(name: "나트륨", value: nutritionInfo.sodium)
+        addNutritionRow(name: "탄수화물", value: nutritionInfo.carbs)
+        addNutritionRow(name: "당류", value: nutritionInfo.sugars)
+        addNutritionRow(name: "지방", value: nutritionInfo.fat)
+        addNutritionRow(name: "트랜스지방", value: nutritionInfo.transFat)
+        addNutritionRow(name: "포화지방", value: nutritionInfo.saturatedFat)
+        addNutritionRow(name: "콜레스테롤", value: nutritionInfo.cholesterol)
+        addNutritionRow(name: "단백질", value: nutritionInfo.protein)
+    }
+}
+
+// MARK: - Private Methods
+private extension ProductNutritionView {
+    func setupUI() {
+        backgroundColor = .white
+
+        [
+            totalAmountLabel,
+            kcalLabel,
+            percentInfoLabel,
+            separatorView,
+            nutritionStackView,
+            footnoteLabel
+        ].forEach {
+            addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        NSLayoutConstraint.activate([
+            totalAmountLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 10),
+            totalAmountLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+
+            kcalLabel.topAnchor.constraint(equalTo: totalAmountLabel.bottomAnchor, constant: 4),
+            kcalLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+
+            percentInfoLabel.bottomAnchor.constraint(equalTo: kcalLabel.bottomAnchor, constant: -4),
+            percentInfoLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
+
+            separatorView.topAnchor.constraint(equalTo: kcalLabel.bottomAnchor, constant: 10),
+            separatorView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            separatorView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
+            separatorView.heightAnchor.constraint(equalToConstant: 1),
+
+            nutritionStackView.topAnchor.constraint(equalTo: separatorView.bottomAnchor, constant: 15),
+            nutritionStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            nutritionStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
+
+            footnoteLabel.topAnchor.constraint(greaterThanOrEqualTo: nutritionStackView.bottomAnchor, constant: 20),
+            footnoteLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            footnoteLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
+            footnoteLabel.bottomAnchor.constraint(equalTo: self.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+        ])
+    }
+
+    // 영양성분 한 줄을 생성하여 스택뷰에 추가하는 헬퍼 메서드
+    func addNutritionRow(name: String, value: NutrientValue) {
+        let hStack = UIStackView()
+        hStack.axis = .horizontal
+        hStack.distribution = .fill
+
+        let nameLabel = UILabel()
+        nameLabel.font = UIFont.systemFont(ofSize: 15)
+        nameLabel.textColor = .darkGray
+
+        // amount가 nil이면 "-"로 표시, 아니면 "값 + 단위"로 표시
+        let amountText = value.amount.map { "\($0)\(value.unit)" } ?? "-"
+        nameLabel.text = "\(name) \(amountText)"
+
+        let percentLabel = UILabel()
+        percentLabel.font = UIFont.boldSystemFont(ofSize: 15)
+        percentLabel.textColor = .black
+        percentLabel.textAlignment = .right
+
+        // percentage가 nil이면 "-"로 표시, 아니면 "값%"로 표시
+        percentLabel.text = value.percentage.map { "\($0)%" } ?? "-"
+
+        hStack.addArrangedSubview(nameLabel)
+        hStack.addArrangedSubview(percentLabel)
+
+        nutritionStackView.addArrangedSubview(hStack)
+    }
+}

--- a/CaloLink/Source/Presentation/DetailScene/View/ProductPriceView.swift
+++ b/CaloLink/Source/Presentation/DetailScene/View/ProductPriceView.swift
@@ -1,0 +1,121 @@
+//
+//  ProductPriceView.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import UIKit
+
+// MARK: - ProductPriceView
+final class ProductPriceView: UIView {
+    // MARK: - UI Components
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.showsVerticalScrollIndicator = true
+        return scrollView
+    }()
+
+    private let contentView = UIView()
+
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 13
+        return stackView
+    }()
+
+    // MARK: - Initializer
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public 메서드
+    // ViewModel로부터 받은 데이터로 View를 업데이트
+    public func updateShopLinks(with shopLinks: [ShopLink]) {
+        // 기존에 있던 가격 정보 뷰들을 모두 제거
+        stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        // 새로운 데이터로 가격 정보 뷰들을 다시 만듦
+        shopLinks.forEach { addPriceRow(for: $0) }
+    }
+}
+
+// MARK: - Private 메서드
+private extension ProductPriceView {
+    // 가격 정보 한 줄을 생성하여 스택뷰에 추가하는 헬퍼 메서드
+    func addPriceRow(for shopLink: ShopLink) {
+        let hStack = UIStackView()
+        hStack.axis = .horizontal
+        hStack.distribution = .equalSpacing
+
+        let linkButton = UIButton(type: .system)
+        linkButton.setTitle(shopLink.mallName, for: .normal)
+        linkButton.titleLabel?.font = UIFont.systemFont(ofSize: 18)
+        linkButton.tintColor = .darkGray
+        linkButton.contentHorizontalAlignment = .left
+
+        // 버튼에 URL 열기 액션을 추가
+        if let url = shopLink.linkURL {
+            linkButton.addAction(UIAction { _ in
+                UIApplication.shared.open(url)
+            }, for: .touchUpInside)
+        }
+
+        let priceLabel = UILabel()
+        priceLabel.font = UIFont.boldSystemFont(ofSize: 18)
+        priceLabel.textColor = .black
+        priceLabel.text = formatPrice(shopLink.price)
+
+        hStack.addArrangedSubview(linkButton)
+        hStack.addArrangedSubview(priceLabel)
+
+        stackView.addArrangedSubview(hStack)
+    }
+
+    // 숫자를 원화 형식으로 변환
+    func formatPrice(_ price: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return (formatter.string(from: NSNumber(value: price)) ?? "\(price)") + "원"
+    }
+
+    func setupUI() {
+        backgroundColor = .white
+
+        addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        contentView.addSubview(stackView)
+
+        [
+            scrollView,
+            contentView,
+            stackView
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: self.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+
+            contentView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20)
+        ])
+    }
+}

--- a/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
+++ b/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
@@ -1,0 +1,65 @@
+//
+//  DetailViewModel.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import Foundation
+
+// MARK: - DetailViewModel
+final class DetailViewModel {
+    // MARK: - 프로퍼티
+    private let productId: String
+    private let getProductDetailUseCase: GetProductDetailUseCaseProtocol
+
+    // MARK: - Output to ViewController
+    // View에 전달할 데이터 및 상태
+    private(set) var productDetail: ProductDetail?
+    private(set) var isLoading: Bool = false {
+        didSet {
+            // 로딩 상태가 변경되면 View에 알림
+            self.onUpdate?()
+        }
+    }
+    private(set) var error: Error?
+
+    // ViewModel의 상태가 변경될 때마다 호출될 클로저
+    var onUpdate: (() -> Void)?
+
+    // MARK: - Initializer
+    init(
+        productId: String,
+        getProductDetailUseCase: GetProductDetailUseCaseProtocol
+    ) {
+        self.productId = productId
+        self.getProductDetailUseCase = getProductDetailUseCase
+    }
+
+    // MARK: - 메서드
+    // ViewController의 viewDidLoad에서 호출될 메서드
+    func viewDidLoad() {
+        fetchProductDetail()
+    }
+
+    // 상품 상세 정보를 가져오는 메서드
+    private func fetchProductDetail() {
+        self.isLoading = true
+
+        getProductDetailUseCase.execute(productId: productId) { [weak self] result in
+            // 네트워크 응답은 백그라운드 스레드에서 올 수 있으므로 UI 업데이트를 위해 메인 스레드로 전환
+            DispatchQueue.main.async {
+                self?.isLoading = false
+                switch result {
+                case .success(let detail):
+                    self?.productDetail = detail
+                    // 데이터가 성공적으로 로드되었음을 View에 알림
+                    self?.onUpdate?()
+                case .failure(let error):
+                    self?.error = error
+                    // 에러가 발생했음을 View에 알림
+                }
+            }
+        }
+    }
+}

--- a/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
+++ b/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
@@ -14,8 +14,20 @@ final class DetailViewModel {
     private let getProductDetailUseCase: GetProductDetailUseCaseProtocol
 
     // MARK: - Output to ViewController
-    // View에 전달할 데이터 및 상태
-    private(set) var productDetail: ProductDetail?
+    // UseCase로부터 받은 원본 데이터
+    private var productDetail: ProductDetail?
+
+    // View는 아래의 가공된 데이터들을 사용
+    var productName: String? { productDetail?.name }
+    var imageURL: URL? { productDetail?.imageURL }
+    var nutritionInfo: NutritionInfo? { productDetail?.nutritionInfo }
+
+    // 가격이 낮은 순으로 정렬된 쇼핑몰 링크 배열
+    var sortedShopLinks: [ShopLink] {
+        // 원본 shopLinks를 가격 오름차순으로 정렬하여 반환
+        return productDetail?.shopLinks.sorted { $0.price < $1.price } ?? []
+    }
+
     private(set) var isLoading: Bool = false {
         didSet {
             // 로딩 상태가 변경되면 View에 알림
@@ -52,12 +64,12 @@ final class DetailViewModel {
                 self?.isLoading = false
                 switch result {
                 case .success(let detail):
+                    // 원본 데이터를 저장하고, View에 업데이트 신호를 보냄
                     self?.productDetail = detail
                     // 데이터가 성공적으로 로드되었음을 View에 알림
                     self?.onUpdate?()
                 case .failure(let error):
                     self?.error = error
-                    // 에러가 발생했음을 View에 알림
                 }
             }
         }


### PR DESCRIPTION
<!-- 제목은 "OO을 해서 OO가 됩니다.", "OO화면의 UI를 구현합니다." 로 올려주세요 -->

# 개요
<!-- 개요는 와이어프레임이나, 이슈등을 사용하여 작업의 시작점을 알려줍니다. -->
- #8 
- 이전에 구축한 `DIContainer`와 `MockProductRepository`를 기반으로 앱의 핵심 기능 중 하나인 상품 상세 화면의 UI를 구현합니다.
- 이 작업을 통해 설계된 MVVM + Clean 아키텍처가 실제로 화면단까지 올바르게 작동하는지 검증하는 것을 목표로 합니다.

# 작업 내용
<!-- 작업 내용에는 "무엇"은 간단하게 적고, 왜 이렇게 작성했는지 위주로 적습니다. -->
<!-- UI 구현의 경우 가능한 스크린샷을 포함합니다. -->

<img width="447" height="846" alt="스크린샷 2025-08-13 14 31 24" src="https://github.com/user-attachments/assets/eca729aa-59d8-4133-b344-6ddc0bd123c4" />

<img width="447" height="846" alt="스크린샷 2025-08-13 14 31 28" src="https://github.com/user-attachments/assets/2e9c877e-9875-4e43-b735-9ea198654fad" />

- DetailViewModel 구현
  - `GetProductDetailUseCase`를 통해 데이터를 요청하고 View가 사용하기 좋은 형태로 데이터를 가공하는 `DetailViewModel`을 구현했습니다.
  - `shopLinks`를 가격순으로 정렬하는 로직을 ViewModel에 배치하여 View는 데이터 가공에 신경쓸 필요 없이 정렬된 데이터를 받아 화면에 그리기만 하면 하도록 역할을 분리했습니다. 데이터 바인딩은 `onUpdate`클로저를 사용했습니다.
- 재사용 가능한 자식 View 구현
  - `ProductNutritionView`와 `ProductPriceView`를 각각의 파일로 분리하여 구현했습니다.
  - 각 View는 자신의 책임(영양정보 표시, 가격정보 표시)에만 집중하도록 설계했습니다. `updateNutritionInfo(with:)`와 같은 명확한 이름의 메서드를 통해 외부로부터 데이터를 받아 UI를 갱신하므로 재사용성이 높고 독립적으로 관리하기 용이합니다.
- DetailViewController 구현
  - `DIContainer`로부터 `DetailViewModel`을 주입받는 `DetailViewController`를 구현했습니다.
  - ViewController는 ViewModel의 상태(`isLoading`, `productDetail` 등)를 구독하고 자식 View들에게 데이터를 전달하며 `UISegmentedControl`의 이벤트를 처리하는 조립과 연결의 역할에 집중하도록 했습니다.

# 기타
<!-- 기타 얘기할 사항이 있으면 얘기합니다. -->
- 현재는 `MockProductRepository`를  사용하여 고정된 가짜 데이터를 화면에 표시하고 있습니다.
- `SceneDelegate`에서 `DetailViewController`를 임시로 시작점으로 설정하여 테스트를 진행했습니다.
