### PR TITLE
[Feat] 검색 결과 목록 화면의 UI를 구현합니다.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 # 실행될 작업들의 목록
 jobs:
-  build-and-test:
+    build-project:
     # 이 작업은 GitHub에서 제공하는 최신 macOS 환경에서 실행됨
     runs-on: macos-15
 
@@ -38,13 +38,24 @@ jobs:
 #      - name: List available simulators
 #        run: xcrun simctl list devices available
 
-      # 6. 프로젝트 빌드 및 테스트 실행
-      - name: Build and Test
+      # 6. 프로젝트 빌드 실행
+      - name: Build Project
         working-directory: ./CaloLink
         run: |
-          xcodebuild test \
+          # test 대신 build 액션을 사용하여 컴파일만 진행
+          xcodebuild build \
             -project CaloLink.xcodeproj \
             -scheme CaloLink \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -skipPackagePluginValidation \
             -skipMacroValidation
+
+#      # 6. 프로젝트 빌드 및 테스트 실행
+#      - name: Build and Test
+#        working-directory: ./CaloLink
+#        run: |
+#          xcodebuild test \
+#            -project CaloLink.xcodeproj \
+#            -scheme CaloLink \
+#            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+#            -skipPackagePluginValidation \
+#            -skipMacroValidation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 # 실행될 작업들의 목록
 jobs:
-    build-project:
+  build-project:
     # 이 작업은 GitHub에서 제공하는 최신 macOS 환경에서 실행됨
     runs-on: macos-15
 
@@ -50,12 +50,14 @@ jobs:
             -skipMacroValidation
 
 #      # 6. 프로젝트 빌드 및 테스트 실행
-#      - name: Build and Test
+#      - name: Build and Test (Inactive)
+#        if: false # 이 단계를 실행하지 않도록 설정
 #        working-directory: ./CaloLink
 #        run: |
-#          xcodebuild test \
-#            -project CaloLink.xcodeproj \
-#            -scheme CaloLink \
-#            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
-#            -skipPackagePluginValidation \
-#            -skipMacroValidation
+#          # 나중에 테스트 코드를 추가하면 아래 주석을 해제하고 위 'Build Project' 단계를 주석 처리하세요.
+#          # xcodebuild test \
+#          #   -project CaloLink.xcodeproj \
+#          #   -scheme CaloLink \
+#          #   -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+#          #   -skipPackagePluginValidation \
+#          #   -skipMacroValidation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,13 @@ jobs:
         working-directory: ./CaloLink
         run: |
           # test 대신 build 액션을 사용하여 컴파일만 진행
+          # CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 옵션으로 코드 서명을 비활성화
           xcodebuild build \
             -project CaloLink.xcodeproj \
             -scheme CaloLink \
             -skipPackagePluginValidation \
-            -skipMacroValidation
+            -skipMacroValidation \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
 #      # 6. 프로젝트 빌드 및 테스트 실행
 #      - name: Build and Test (Inactive)
@@ -60,4 +62,5 @@ jobs:
 #          #   -scheme CaloLink \
 #          #   -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
 #          #   -skipPackagePluginValidation \
-#          #   -skipMacroValidation
+#          #   -skipMacroValidation \
+#          #   CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		BC7343352E4C2D9300A24ADE /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343342E4C2D9000A24ADE /* DetailViewModel.swift */; };
 		BC7343372E4C2DA400A24ADE /* ProductNutritionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343362E4C2D9B00A24ADE /* ProductNutritionView.swift */; };
 		BC73433A2E4C2DAE00A24ADE /* ProductPriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343392E4C2DAB00A24ADE /* ProductPriceView.swift */; };
+		BC88BC172E4C979300F4B556 /* ListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC162E4C978D00F4B556 /* ListViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		BC7343342E4C2D9000A24ADE /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
 		BC7343362E4C2D9B00A24ADE /* ProductNutritionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNutritionView.swift; sourceTree = "<group>"; };
 		BC7343392E4C2DAB00A24ADE /* ProductPriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceView.swift; sourceTree = "<group>"; };
+		BC88BC162E4C978D00F4B556 /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -247,6 +249,7 @@
 		BC7342D82E4AF99500A24ADE /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC162E4C978D00F4B556 /* ListViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -535,6 +538,7 @@
 				BC7342EC2E4B4D4600A24ADE /* SearchProductsUseCase.swift in Sources */,
 				BC7342FF2E4B587400A24ADE /* ProductDetailDTO.swift in Sources */,
 				BC7343152E4B7B6A00A24ADE /* APIConstant.swift in Sources */,
+				BC88BC172E4C979300F4B556 /* ListViewModel.swift in Sources */,
 				BC7343082E4B62F500A24ADE /* NetworkService.swift in Sources */,
 				BC7343062E4B608C00A24ADE /* ProductAPI.swift in Sources */,
 				BC73433A2E4C2DAE00A24ADE /* ProductPriceView.swift in Sources */,

--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		BC7343372E4C2DA400A24ADE /* ProductNutritionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343362E4C2D9B00A24ADE /* ProductNutritionView.swift */; };
 		BC73433A2E4C2DAE00A24ADE /* ProductPriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7343392E4C2DAB00A24ADE /* ProductPriceView.swift */; };
 		BC88BC172E4C979300F4B556 /* ListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC162E4C978D00F4B556 /* ListViewModel.swift */; };
+		BC88BC192E4C996800F4B556 /* ProductListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC182E4C996300F4B556 /* ProductListCell.swift */; };
+		BC88BC1D2E4C9A7700F4B556 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC1C2E4C9A6F00F4B556 /* ListViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +80,8 @@
 		BC7343362E4C2D9B00A24ADE /* ProductNutritionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductNutritionView.swift; sourceTree = "<group>"; };
 		BC7343392E4C2DAB00A24ADE /* ProductPriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceView.swift; sourceTree = "<group>"; };
 		BC88BC162E4C978D00F4B556 /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
+		BC88BC182E4C996300F4B556 /* ProductListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListCell.swift; sourceTree = "<group>"; };
+		BC88BC1C2E4C9A6F00F4B556 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -257,6 +261,8 @@
 		BC7342D92E4AF99900A24ADE /* View */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC1C2E4C9A6F00F4B556 /* ListViewController.swift */,
+				BC88BC182E4C996300F4B556 /* ProductListCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -533,6 +539,7 @@
 				BC7342E42E4B427900A24ADE /* ProductDetail.swift in Sources */,
 				BC7343372E4C2DA400A24ADE /* ProductNutritionView.swift in Sources */,
 				BC7343332E4C2D1600A24ADE /* DetailViewController.swift in Sources */,
+				BC88BC192E4C996800F4B556 /* ProductListCell.swift in Sources */,
 				BC7342E22E4B3EA300A24ADE /* Product.swift in Sources */,
 				BC7342FD2E4B56C800A24ADE /* ProductListResponseDTO.swift in Sources */,
 				BC7342EC2E4B4D4600A24ADE /* SearchProductsUseCase.swift in Sources */,
@@ -547,6 +554,7 @@
 				BC7343252E4C120C00A24ADE /* MockProductRepository.swift in Sources */,
 				BC7342C02E4AE5EF00A24ADE /* ViewController.swift in Sources */,
 				BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */,
+				BC88BC1D2E4C9A7700F4B556 /* ListViewController.swift in Sources */,
 				BC7342C12E4AE5EF00A24ADE /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CaloLink/Source/Application/DIContainer.swift
+++ b/CaloLink/Source/Application/DIContainer.swift
@@ -23,7 +23,6 @@ final class DIContainer {
     lazy var searchProductsUseCase: SearchProductsUseCaseProtocol = SearchProductsUseCase(productRepository: productRepository)
     lazy var getProductDetailUseCase: GetProductDetailUseCaseProtocol = GetProductDetailUseCase(productRepository: productRepository)
 
-/*
     // MARK: - 조립 라인 (Factory Methods)
 
     // MARK: - 검색 결과 목록 Scene
@@ -35,10 +34,14 @@ final class DIContainer {
 
     // ListViewController를 생성하는 팩토리 메서드
     func makeListViewController() -> ListViewController {
-        // "makeListViewModel" 조립 라인을 호출하여 새로운 ViewModel을 만들고 주입
-        return ListViewController(viewModel: makeListViewModel())
+        // "makeListViewModel"을 호출하여 ViewModel을 만들고,
+        // diContainer 자기 자신(self)도 함께 주입
+        return ListViewController(
+            viewModel: makeListViewModel(),
+            diContainer: self
+        )
     }
- */
+
     // MARK: - 상품 상세 Scene
     // DetailViewModel을 생성하는 팩토리 메서드
     func makeDetailViewModel(productId: String) -> DetailViewModel {
@@ -50,6 +53,8 @@ final class DIContainer {
 
     // DetailViewController를 생성하는 팩토리 메서드
     func makeDetailViewController(productId: String) -> DetailViewController {
-        return DetailViewController(viewModel: makeDetailViewModel(productId: productId))
+        return DetailViewController(
+            viewModel: makeDetailViewModel(productId: productId)
+        )
     }
 }

--- a/CaloLink/Source/Application/SceneDelegate.swift
+++ b/CaloLink/Source/Application/SceneDelegate.swift
@@ -11,18 +11,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
+    let diContainer = DIContainer()
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        let diContainer = DIContainer()
+        // (임시) ListViewController를 첫 화면으로 설정
+        let listViewController = diContainer.makeListViewController()
 
-        // 검증을 위해 임시로 사용
-        // 인스턴스를 통해 팩토리 메서드를 호출하고 테스트할 상품의 ID를 전달
-        // MockRepository에 있는 ID 중 하나인 "P001"을 사용
-        let detailViewController = diContainer.makeDetailViewController(productId: "P001")
-
-        let navigationController = UINavigationController(rootViewController: detailViewController)
+        let navigationController = UINavigationController(rootViewController: listViewController)
 
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = navigationController

--- a/CaloLink/Source/Data/Repository/MockProductRepository.swift
+++ b/CaloLink/Source/Data/Repository/MockProductRepository.swift
@@ -47,6 +47,86 @@ final class MockProductRepository: ProductRepositoryProtocol {
                         KeyNutrient(name: "나트륨", value: "250mg"),
                         KeyNutrient(name: "탄수화물", value: "50g")
                     ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
+                ),
+                Product(
+                    id: "P002",
+                    name: "고단백 프로틴 쉐이크",
+                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    price: 3000,
+                    keyNutrients: [
+                        KeyNutrient(name: "단백질", value: "30g"),
+                        KeyNutrient(name: "당류", value: "2g")
+                    ]
                 )
             ]
 

--- a/CaloLink/Source/Data/Repository/MockProductRepository.swift
+++ b/CaloLink/Source/Data/Repository/MockProductRepository.swift
@@ -21,7 +21,7 @@ final class MockProductRepository: ProductRepositoryProtocol {
                 Product(
                     id: "P001",
                     name: "맛있는 닭가슴살 100g (검색어: \(query.searchText))",
-                    imageURL: URL(string: "https://example.com/images/chicken_breast.jpg"),
+                    imageURL: URL(string: "https://picsum.photos/seed/P001/200"),
                     price: 2500,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "25g"),
@@ -41,7 +41,7 @@ final class MockProductRepository: ProductRepositoryProtocol {
                 Product(
                     id: "P003",
                     name: "저염 현미밥 도시락",
-                    imageURL: URL(string: "https://example.com/images/rice_box.jpg"),
+                    imageURL: URL(string: "https://picsum.photos/seed/P003/200"),
                     price: 4500,
                     keyNutrients: [
                         KeyNutrient(name: "나트륨", value: "250mg"),
@@ -49,9 +49,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P004",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P004/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -59,9 +59,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P005",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P005/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -69,9 +69,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P006",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P006/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -79,9 +79,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P007",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P007/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -89,9 +89,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P008",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P008/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -99,9 +99,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P009",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P009/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -109,9 +109,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P010",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P010/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -119,9 +119,9 @@ final class MockProductRepository: ProductRepositoryProtocol {
                     ]
                 ),
                 Product(
-                    id: "P002",
+                    id: "P011",
                     name: "고단백 프로틴 쉐이크",
-                    imageURL: nil, // 이미지가 없는 경우 테스트
+                    imageURL: URL(string: "https://picsum.photos/seed/P011/200"),
                     price: 3000,
                     keyNutrients: [
                         KeyNutrient(name: "단백질", value: "30g"),
@@ -145,7 +145,7 @@ final class MockProductRepository: ProductRepositoryProtocol {
             let mockDetail = ProductDetail(
                 id: productId,
                 name: "맛있는 닭가슴살 100g (상세)",
-                imageURL: URL(string: "https://example.com/images/chicken_breast.jpg"),
+                imageURL: URL(string: "https://picsum.photos/seed/\(productId)/400"),
                 nutritionInfo: NutritionInfo(
                     totalSize: 100,
                     calories: 130,

--- a/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
+++ b/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
@@ -148,6 +148,13 @@ private extension DetailViewController {
             // ViewModel의 상태가 변경되면 UI를 업데이트
             self.updateUI()
         }
+
+        viewModel.onShowErrorAlert = { [weak self] message in
+            // UIAlertController를 사용하여 에러 메시지 표시
+            let alert = UIAlertController(title: "에러 발생", message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            self?.present(alert, animated: true)
+        }
     }
 
     // ViewModel로부터 받은 데이터로 UI 컴포넌트를 채움

--- a/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
+++ b/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
@@ -39,6 +39,9 @@ final class DetailViewModel {
     // ViewModel의 상태가 변경될 때마다 호출될 클로저
     var onUpdate: (() -> Void)?
 
+    // 에러 발생 시 에러 메시지와 함께 얼럿을 띄우도록 요청하는 클로저
+    var onShowErrorAlert: ((String) -> Void)?
+
     // MARK: - Initializer
     init(
         productId: String,
@@ -70,7 +73,8 @@ final class DetailViewModel {
                     self?.onUpdate?()
                 case .failure(let error):
                     self?.error = error
-                    // TODO: - 얼럿 추가?
+                    // 에러가 발생하면 에러 메시지와 함께 얼럿을 띄우도록 View에 요청
+                    self?.onShowErrorAlert?(error.localizedDescription)
                 }
             }
         }

--- a/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
+++ b/CaloLink/Source/Presentation/DetailScene/ViewModel/DetailViewModel.swift
@@ -70,6 +70,7 @@ final class DetailViewModel {
                     self?.onUpdate?()
                 case .failure(let error):
                     self?.error = error
+                    // TODO: - 얼럿 추가?
                 }
             }
         }

--- a/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
@@ -1,0 +1,165 @@
+//
+//  ListViewController.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import UIKit
+
+// MARK: - ListViewController
+final class ListViewController: UIViewController {
+    // MARK: - 프로퍼티
+    private let viewModel: ListViewModel
+    private let diContainer: DIContainer
+
+    // MARK: - UI Components
+    private let filterButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.image = UIImage(systemName: "line.3.horizontal.decrease")
+        config.title = "필터"
+        config.imagePadding = 4
+        config.baseForegroundColor = .black
+        config.background.strokeColor = .systemGray4
+        config.background.strokeWidth = 1
+        config.background.cornerRadius = 8
+        config.contentInsets = .init(top: 8, leading: 12, bottom: 8, trailing: 12)
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    private let sortButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.title = "기본순"
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 12, weight: .regular)
+        config.image = UIImage(systemName: "chevron.down", withConfiguration: symbolConfig)
+        config.imagePlacement = .trailing
+        config.imagePadding = 4
+        config.baseForegroundColor = .black
+        let button = UIButton(configuration: config)
+        return button
+    }()
+
+    private let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.rowHeight = 130
+        tableView.separatorInset = .zero
+        tableView.register(
+            ProductListCell.self,
+            forCellReuseIdentifier: ProductListCell.identifier
+        )
+        return tableView
+    }()
+
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    // MARK: - Initializer
+    init(viewModel: ListViewModel, diContainer: DIContainer) {
+        self.viewModel = viewModel
+        self.diContainer = diContainer
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupTableView()
+        bindViewModel()
+
+        viewModel.fetchProducts(with: .default)
+    }
+}
+
+// MARK: - UI Setup
+private extension ListViewController {
+    func setupUI() {
+        view.backgroundColor = .white
+        navigationItem.title = "검색 결과" // TODO: 실제 검색어로 변경
+
+        let filterStackView = UIStackView(arrangedSubviews: [filterButton, UIView(), sortButton])
+        filterStackView.axis = .horizontal
+
+        [filterStackView, tableView, activityIndicator].forEach {
+            view.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        NSLayoutConstraint.activate([
+            filterStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
+            filterStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            filterStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            tableView.topAnchor.constraint(equalTo: filterStackView.bottomAnchor, constant: 10),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+}
+
+// MARK: - Private 메서드
+private extension ListViewController {
+    func bindViewModel() {
+        viewModel.onUpdate = { [weak self] in
+            guard let self = self else { return }
+
+            // 로딩 인디케이터 처리
+            if self.viewModel.isLoading {
+                self.activityIndicator.startAnimating()
+            } else {
+                self.activityIndicator.stopAnimating()
+            }
+
+            self.tableView.reloadData()
+        }
+
+        viewModel.onShowErrorAlert = { [weak self] message in
+            // UIAlertController를 사용하여 에러 메시지 표시
+            let alert = UIAlertController(title: "에러 발생", message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "확인", style: .default))
+            self?.present(alert, animated: true)
+        }
+    }
+
+    func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+}
+
+// MARK: - UITableView DataSource & Delegate
+extension ListViewController: UITableViewDataSource, UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.products.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ProductListCell.identifier, for: indexPath) as? ProductListCell else {
+            return UITableViewCell()
+        }
+        let product = viewModel.products[indexPath.row]
+        cell.configure(with: product)
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let selectedProduct = viewModel.products[indexPath.row]
+        
+        let detailVC = diContainer.makeDetailViewController(productId: selectedProduct.id)
+        navigationController?.pushViewController(detailVC, animated: true)
+    }
+}

--- a/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
@@ -151,14 +151,14 @@ extension ListViewController: UITableViewDataSource, UITableViewDelegate {
             return UITableViewCell()
         }
         let product = viewModel.products[indexPath.row]
-        cell.configure(with: product)
+        cell.updateContents(with: product)
         return cell
     }
-    
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let selectedProduct = viewModel.products[indexPath.row]
-        
+
         let detailVC = diContainer.makeDetailViewController(productId: selectedProduct.id)
         navigationController?.pushViewController(detailVC, animated: true)
     }

--- a/CaloLink/Source/Presentation/ListScene/View/ProductListCell.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ProductListCell.swift
@@ -1,0 +1,132 @@
+//
+//  ProductListCell.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import UIKit
+
+// MARK: - ProductListCell
+final class ProductListCell: UITableViewCell {
+    static let identifier = "ProductListCell"
+
+    // MARK: - UI Components
+    private let productImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .systemGray6
+        imageView.tintColor = .systemGray4
+        return imageView
+    }()
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        label.textColor = .black
+        label.numberOfLines = 2
+        return label
+    }()
+
+    private let priceLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 18)
+        label.textColor = .black
+        return label
+    }()
+
+    private let nutrientsLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = .darkGray
+        return label
+    }()
+
+    // MARK: - Initializer
+    override init(
+        style: UITableViewCell.CellStyle,
+        reuseIdentifier: String?
+    ) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public 메서드
+    public func updateContents(with product: Product) {
+        nameLabel.text = product.name
+        priceLabel.text = formatPrice(product.price)
+
+        nutrientsLabel.text = product.keyNutrients
+            .map { "\($0.name) \($0.value)" }
+            .joined(separator: " | ")
+
+        let placeholderImage = UIImage(
+            systemName: "photo",
+            withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .light)
+        )
+
+        // 이미지 비동기 로드
+        if let imageURL = product.imageURL {
+            self.productImageView.image = placeholderImage
+
+            DispatchQueue.global().async {
+                if let data = try? Data(contentsOf: imageURL), let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self.productImageView.image = image
+                    }
+                }
+            }
+        } else {
+            self.productImageView.image = placeholderImage
+        }
+    }
+
+    private func formatPrice(_ price: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return (formatter.string(from: NSNumber(value: price)) ?? "\(price)") + "원"
+    }
+}
+
+// MARK: - UI Setup
+private extension ProductListCell {
+    func setupUI() {
+        contentView.backgroundColor = .white
+        [
+            productImageView,
+            nameLabel,
+            priceLabel,
+            nutrientsLabel
+        ].forEach {
+            contentView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        // 셀 선택 시 회색 배경이 나타나도록 설정
+        self.selectionStyle = .default
+
+        NSLayoutConstraint.activate([
+            productImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            productImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            productImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12),
+            productImageView.widthAnchor.constraint(equalTo: productImageView.heightAnchor),
+
+            nameLabel.topAnchor.constraint(equalTo: productImageView.topAnchor),
+            nameLabel.leadingAnchor.constraint(equalTo: productImageView.trailingAnchor, constant: 12),
+            nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+
+            nutrientsLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 8),
+            nutrientsLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
+            nutrientsLabel.trailingAnchor.constraint(equalTo: nameLabel.trailingAnchor),
+
+            priceLabel.bottomAnchor.constraint(equalTo: productImageView.bottomAnchor),
+            priceLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor)
+        ])
+    }
+}

--- a/CaloLink/Source/Presentation/ListScene/View/ProductListCell.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ProductListCell.swift
@@ -71,7 +71,7 @@ final class ProductListCell: UITableViewCell {
             withConfiguration: UIImage.SymbolConfiguration(pointSize: 30, weight: .light)
         )
 
-        // 이미지 비동기 로드
+        // TODO: - 비동기, 이미지 로드 개선
         if let imageURL = product.imageURL {
             self.productImageView.image = placeholderImage
 

--- a/CaloLink/Source/Presentation/ListScene/ViewModel/ListViewModel.swift
+++ b/CaloLink/Source/Presentation/ListScene/ViewModel/ListViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  ListViewModel.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import Foundation
+
+// MARK: - ListViewModel
+final class ListViewModel {
+    // MARK: - 프로퍼티
+    private let searchProductsUseCase: SearchProductsUseCaseProtocol
+
+    private(set) var products: [Product] = []
+    private(set) var isLoading: Bool = false {
+        didSet { self.onUpdate?() }
+    }
+    private(set) var error: Error?
+
+    // ViewModel의 상태가 변경될 때마다 호출될 클로저
+    var onUpdate: (() -> Void)?
+
+    // 에러 발생 시 에러 메시지와 함께 얼럿을 띄우도록 요청하는 클로저
+    var onShowErrorAlert: ((String) -> Void)?
+
+    // MARK: - Initializer
+    init(searchProductsUseCase: SearchProductsUseCaseProtocol) {
+        self.searchProductsUseCase = searchProductsUseCase
+    }
+
+    // MARK: - 메서드
+    // 검색 쿼리로 상품 목록을 가져옴
+    func fetchProducts(with query: SearchQuery) {
+        self.isLoading = true
+
+        searchProductsUseCase.execute(query: query) { [weak self] result in
+            DispatchQueue.main.async {
+                self?.isLoading = false
+                switch result {
+                case .success(let products):
+                    self?.products = products
+                    self?.onUpdate?()
+                case .failure(let error):
+                    self?.error = error
+                    // 에러가 발생하면 에러 메시지와 함께 얼럿을 띄우도록 View에 요청
+                    self?.onShowErrorAlert?(error.localizedDescription)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목은 "OO을 해서 OO가 됩니다.", "OO화면의 UI를 구현합니다." 로 올려주세요 -->

# 개요
<!-- 개요는 와이어프레임이나, 이슈등을 사용하여 작업의 시작점을 알려줍니다. -->
- #5 
- 상세 화면 구현에 이어, 사용자가 검색 결과를 확인할 수 있는 상품 목록 화면의 UI를 구현합니다.
- 이 작업을 통해 앱의 핵심적인 사용자 흐름인 "목록 -> 상세" 플로우를 완성하고, 아키텍처가 올바르게 동작하는지 검증합니다.

# 작업 내용
<!-- 작업 내용에는 "무엇"은 간단하게 적고, 왜 이렇게 작성했는지 위주로 적습니다. -->
<!-- UI 구현의 경우 가능한 스크린샷을 포함합니다. -->

<img width="447" height="846" alt="스크린샷 2025-08-13 19 57 22" src="https://github.com/user-attachments/assets/a38ca532-4d65-4c3b-bd48-a1188a47a16d" />

- ListViewModel 구현
  - `SearchProductsUseCase` 를 통해 상품 목록 데이터를 요청하고, 로딩 및 에러 상태를 관리하는 `ListViewModel`을 구현했습니다.
  - `onUpdate`, `onShowErrorAlert` 클로저를 통해 View에게 상태 변화를 알리는 방식으로 데이터 바인딩 로직을 구성했습니다.

- ProductListCell 구현
  - `UITableView`에 표시될 개별 상품 정보를 담는 커스텀 셀인 `ProductListCell`을 구현했습니다.
  - `updateContents(with:)`메서드를 통해 외부로부터 `Product` 데이터를 주입받아 UI를 갱신하도록 설계하여 셀의 역할을 명확히 하고 재사용성을 높였습니다. 이미지 로딩은 비동기로 처리하여 UI 멈춤 현상을 방지했습니다.

- ListViewController 구현
  - `DIContainer`로부터 `ListViewModel`을 주입받는 `ListViewController`를 구현했습니다.
  - ViewController는 ViewModel의 상태를 구독하여 UI(테이블뷰, 로딩 인디케이터 등)를 갱신하고 사용자의 입력(셀 탭)을 받아 다음 화면으로 전환하는 역할에만 집중하도록 했습니다.

# 기타
<!-- 기타 얘기할 사항이 있으면 얘기합니다. -->
- 현재는 `MockProductRepository`를 사용하여 고정된 가짜 데이터를 화면에 표시하고 있습니다.
- `SceneDelegate`에서 `ListViewController`를 임시로 시작점으로 설정하여 테스트를 진행했습니다.
- 필터 및 정렬 버튼의 실제 기능은 아직 구현되지 않았습니다.
