### PR TITLE
[Feat] 검색 화면 UI 및 내비게이션바 로직을 구현합니다.

### DIFF
--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		BC88BC172E4C979300F4B556 /* ListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC162E4C978D00F4B556 /* ListViewModel.swift */; };
 		BC88BC192E4C996800F4B556 /* ProductListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC182E4C996300F4B556 /* ProductListCell.swift */; };
 		BC88BC1D2E4C9A7700F4B556 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC1C2E4C9A6F00F4B556 /* ListViewController.swift */; };
+		BC88BC2B2E4CC73B00F4B556 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC2A2E4CC73500F4B556 /* SearchViewModel.swift */; };
+		BC88BC2D2E4CC75400F4B556 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC2C2E4CC74F00F4B556 /* SearchViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +84,8 @@
 		BC88BC162E4C978D00F4B556 /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
 		BC88BC182E4C996300F4B556 /* ProductListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListCell.swift; sourceTree = "<group>"; };
 		BC88BC1C2E4C9A6F00F4B556 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		BC88BC2A2E4CC73500F4B556 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
+		BC88BC2C2E4CC74F00F4B556 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -239,6 +243,7 @@
 		BC7342D62E4AF98E00A24ADE /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC2A2E4CC73500F4B556 /* SearchViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -246,6 +251,7 @@
 		BC7342D72E4AF99200A24ADE /* View */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC2C2E4CC74F00F4B556 /* SearchViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -552,8 +558,10 @@
 				BC7342EA2E4B479300A24ADE /* ProductRepositoryProtocol.swift in Sources */,
 				BC7343352E4C2D9300A24ADE /* DetailViewModel.swift in Sources */,
 				BC7343252E4C120C00A24ADE /* MockProductRepository.swift in Sources */,
+				BC88BC2D2E4CC75400F4B556 /* SearchViewController.swift in Sources */,
 				BC7342C02E4AE5EF00A24ADE /* ViewController.swift in Sources */,
 				BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */,
+				BC88BC2B2E4CC73B00F4B556 /* SearchViewModel.swift in Sources */,
 				BC88BC1D2E4C9A7700F4B556 /* ListViewController.swift in Sources */,
 				BC7342C12E4AE5EF00A24ADE /* AppDelegate.swift in Sources */,
 			);

--- a/CaloLink/Source/Application/DIContainer.swift
+++ b/CaloLink/Source/Application/DIContainer.swift
@@ -25,6 +25,21 @@ final class DIContainer {
 
     // MARK: - 조립 라인 (Factory Methods)
 
+    // MARK: - 검색 Scene
+    // SearchViewModel을 생성하는 팩토리 메서드
+    func makeSearchViewModel() -> SearchViewModel {
+        // 지금은 UseCase 의존성이 없으므로 그냥 생성만
+        return SearchViewModel()
+    }
+
+    // SearchViewController를 생성하는 팩토리 메서드
+    func makeSearchViewController() -> SearchViewController {
+        return SearchViewController(
+            viewModel: makeSearchViewModel(),
+            diContainer: self
+        )
+    }
+
     // MARK: - 검색 결과 목록 Scene
     // ListViewModel을 생성하는 팩토리 메서드
     func makeListViewModel() -> ListViewModel {

--- a/CaloLink/Source/Application/SceneDelegate.swift
+++ b/CaloLink/Source/Application/SceneDelegate.swift
@@ -16,10 +16,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        // (임시) ListViewController를 첫 화면으로 설정
-        let listViewController = diContainer.makeListViewController()
+        // (임시) SearchViewController를 첫 화면으로 설정
+        let searchViewController = diContainer.makeSearchViewController()
 
-        let navigationController = UINavigationController(rootViewController: listViewController)
+        let navigationController = UINavigationController(rootViewController: searchViewController)
 
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = navigationController

--- a/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
+++ b/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
@@ -152,7 +152,7 @@ private extension DetailViewController {
             } else {
                 self.activityIndicator.stopAnimating()
             }
-            
+
             // ViewModel의 상태가 변경되면 UI를 업데이트
             self.updateUI()
         }

--- a/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
+++ b/CaloLink/Source/Presentation/DetailScene/View/DetailViewController.swift
@@ -60,6 +60,7 @@ final class DetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        setupNavigationBar()
         bindViewModel()
         viewModel.viewDidLoad() // ViewModel에 화면이 로드되었음을 알림
     }
@@ -132,6 +133,13 @@ private extension DetailViewController {
         let isNutritionSelected = productInfoSegmentedControl.selectedSegmentIndex == 0
         productNutritionView.isHidden = !isNutritionSelected
         productPriceView.isHidden = isNutritionSelected
+    }
+
+    // 내비게이션 바를 설정
+    func setupNavigationBar() {
+        // 기본 뒤로가기 버튼의 텍스트를 숨김
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        self.navigationController?.navigationBar.tintColor = .black
     }
 
     // ViewModel의 상태 변화를 구독하고 UI를 업데이트

--- a/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
@@ -14,6 +14,8 @@ final class ListViewController: UIViewController {
     private let diContainer: DIContainer
 
     // MARK: - UI Components
+    private let searchController = UISearchController(searchResultsController: nil)
+
     private let filterButton: UIButton = {
         var config = UIButton.Configuration.plain()
         config.image = UIImage(systemName: "line.3.horizontal.decrease")
@@ -73,9 +75,15 @@ final class ListViewController: UIViewController {
         super.viewDidLoad()
         setupUI()
         setupTableView()
+        setupSearchController()
         bindViewModel()
+    }
 
-        viewModel.fetchProducts(with: .default)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // 검색창을 활성화하여 Large Title을 접고 바로 키보드를 내림
+        self.navigationItem.searchController?.isActive = true
+        self.navigationItem.searchController?.searchBar.resignFirstResponder()
     }
 }
 
@@ -83,7 +91,6 @@ final class ListViewController: UIViewController {
 private extension ListViewController {
     func setupUI() {
         view.backgroundColor = .white
-        navigationItem.title = "검색 결과" // TODO: 실제 검색어로 변경
 
         let filterStackView = UIStackView(arrangedSubviews: [filterButton, UIView(), sortButton])
         filterStackView.axis = .horizontal
@@ -111,6 +118,25 @@ private extension ListViewController {
 
 // MARK: - Private 메서드
 private extension ListViewController {
+    func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+    }
+
+    // 내비게이션 바에 SearchController를 설정
+    func setupSearchController() {
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        self.navigationController?.navigationBar.tintColor = .black
+        self.navigationItem.searchController = searchController
+        self.navigationItem.hidesSearchBarWhenScrolling = false
+
+        searchController.searchBar.delegate = self
+        searchController.searchBar.placeholder = "다른 상품 검색하기"
+
+        // ViewModel이 기억하고 있는 검색어로 SearchBar 텍스트를 설정
+        searchController.searchBar.text = viewModel.currentQuery?.searchText
+    }
+
     func bindViewModel() {
         viewModel.onUpdate = { [weak self] in
             guard let self = self else { return }
@@ -132,10 +158,22 @@ private extension ListViewController {
             self?.present(alert, animated: true)
         }
     }
+}
 
-    func setupTableView() {
-        tableView.dataSource = self
-        tableView.delegate = self
+// MARK: - UISearchBarDelegate
+extension ListViewController: UISearchBarDelegate {
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let searchText = searchBar.text, !searchText.isEmpty else { return }
+
+        // 새로운 화면으로 push하는 대신 현재 ViewModel의 데이터를 새로고침
+        let newQuery = SearchQuery(searchText: searchText,
+                                     sortOption: .defaultOrder,
+                                     filterOption: .default,
+                                     page: 1)
+        viewModel.fetchProducts(with: newQuery)
+
+        // 검색 후 키보드를 내림
+        searchController.searchBar.resignFirstResponder()
     }
 }
 

--- a/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
@@ -165,15 +165,16 @@ extension ListViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchText = searchBar.text, !searchText.isEmpty else { return }
 
-        // 새로운 화면으로 push하는 대신 현재 ViewModel의 데이터를 새로고침
-        let newQuery = SearchQuery(searchText: searchText,
-                                     sortOption: .defaultOrder,
-                                     filterOption: .default,
-                                     page: 1)
-        viewModel.fetchProducts(with: newQuery)
+        // 새로운 ListViewController를 push
+        let query = SearchQuery(searchText: searchText,
+                                  sortOption: .defaultOrder,
+                                  filterOption: .default,
+                                  page: 1)
 
-        // 검색 후 키보드를 내림
-        searchController.searchBar.resignFirstResponder()
+        let newListVC = self.diContainer.makeListViewController()
+        newListVC.viewModel.fetchProducts(with: query)
+
+        self.navigationController?.pushViewController(newListVC, animated: true)
     }
 }
 

--- a/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
+++ b/CaloLink/Source/Presentation/ListScene/View/ListViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 // MARK: - ListViewController
 final class ListViewController: UIViewController {
     // MARK: - 프로퍼티
-    private let viewModel: ListViewModel
+    let viewModel: ListViewModel
     private let diContainer: DIContainer
 
     // MARK: - UI Components

--- a/CaloLink/Source/Presentation/ListScene/ViewModel/ListViewModel.swift
+++ b/CaloLink/Source/Presentation/ListScene/ViewModel/ListViewModel.swift
@@ -24,6 +24,9 @@ final class ListViewModel {
     // 에러 발생 시 에러 메시지와 함께 얼럿을 띄우도록 요청하는 클로저
     var onShowErrorAlert: ((String) -> Void)?
 
+    // 현재 화면에 표시 중인 데이터의 검색 쿼리
+    private(set) var currentQuery: SearchQuery?
+ 
     // MARK: - Initializer
     init(searchProductsUseCase: SearchProductsUseCaseProtocol) {
         self.searchProductsUseCase = searchProductsUseCase
@@ -32,6 +35,7 @@ final class ListViewModel {
     // MARK: - 메서드
     // 검색 쿼리로 상품 목록을 가져옴
     func fetchProducts(with query: SearchQuery) {
+        self.currentQuery = query
         self.isLoading = true
 
         searchProductsUseCase.execute(query: query) { [weak self] result in

--- a/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
+++ b/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
@@ -70,7 +70,7 @@ private extension SearchViewController {
     // 내비게이션바에 SearchController를 설정
     func setupSearchController() {
         self.navigationItem.searchController = searchController
-        self.navigationItem.title = "상품 검색"
+        self.navigationItem.title = "검색"
         // 스크롤 시에도 검색창이 항상 보이도록 설정
         self.navigationItem.hidesSearchBarWhenScrolling = false
 

--- a/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
+++ b/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
@@ -5,3 +5,113 @@
 //  Created by 김성훈 on 8/13/25.
 //
 
+import UIKit
+
+// MARK: - SearchViewController
+final class SearchViewController: UIViewController {
+    // MARK: - 프로퍼티
+    private let viewModel: SearchViewModel
+    private let diContainer: DIContainer
+
+    // MARK: - UI Components
+    private let searchController = UISearchController(searchResultsController: nil)
+
+    private let infoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "찾고 싶은 상품의 이름을 검색해 보세요."
+        label.textColor = .systemGray
+        label.font = .systemFont(ofSize: 16)
+        return label
+    }()
+
+    // MARK: - Initializer
+    init(viewModel: SearchViewModel, diContainer: DIContainer) {
+        self.viewModel = viewModel
+        self.diContainer = diContainer
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupSearchController()
+        bindViewModel()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // 화면이 나타나면 바로 키보드가 올라오도록 설정
+        searchController.searchBar.becomeFirstResponder()
+    }
+}
+
+// MARK: - UI Setup
+private extension SearchViewController {
+    func setupUI() {
+        view.backgroundColor = .white
+
+        view.addSubview(infoLabel)
+        infoLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            infoLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            infoLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -50)
+        ])
+    }
+}
+
+// MARK: - Private Methods
+private extension SearchViewController {
+    // 내비게이션바에 SearchController를 설정
+    func setupSearchController() {
+        self.navigationItem.searchController = searchController
+        self.navigationItem.title = "상품 검색"
+        // 스크롤 시에도 검색창이 항상 보이도록 설정
+        self.navigationItem.hidesSearchBarWhenScrolling = false
+
+        searchController.searchBar.delegate = self
+        searchController.searchBar.placeholder = "예) 닭가슴살"
+
+        // Cancel 버튼 텍스트 및 색상 변경
+        UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]).title = "취소"
+        searchController.searchBar.tintColor = .black
+    }
+
+    // ViewModel의 상태 변화를 구독하고 화면 전환 로직을 처리합니다.
+    func bindViewModel() {
+        viewModel.onSearchTriggered = { [weak self] searchText in
+            guard let self = self else { return }
+
+            // 검색어를 포함한 SearchQuery를 생성 (필터/정렬은 기본값 사용)
+            let query = SearchQuery(searchText: searchText,
+                                    sortOption: .defaultOrder,
+                                    filterOption: .default,
+                                    page: 1)
+
+            // DIContainer를 통해 ListViewController를 생성
+            let listVC = self.diContainer.makeListViewController()
+
+            // ListViewController의 ViewModel에게 데이터 로딩을 시작하라고 알림
+            listVC.viewModel.fetchProducts(with: query)
+
+            // 생성된 화면으로 이동
+            self.navigationController?.pushViewController(listVC, animated: true)
+        }
+    }
+}
+
+// MARK: - UISearchBarDelegate
+extension SearchViewController: UISearchBarDelegate {
+    // 사용자가 키보드의 "Search" 버튼을 눌렀을 때 호출됨
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let searchText = searchBar.text, !searchText.isEmpty else { return }
+
+        // ViewModel에게 검색을 시작하라고 알림
+        viewModel.search(with: searchText)
+    }
+}

--- a/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
+++ b/CaloLink/Source/Presentation/SearchScene/View/SearchViewController.swift
@@ -1,0 +1,7 @@
+//
+//  SearchViewController.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+

--- a/CaloLink/Source/Presentation/SearchScene/ViewModel/SearchViewModel.swift
+++ b/CaloLink/Source/Presentation/SearchScene/ViewModel/SearchViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  SearchViewModel.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/13/25.
+//
+
+import Foundation
+
+// MARK: - SearchViewModel
+final class SearchViewModel {
+    // MARK: - Output to VC
+    // 사용자가 검색을 시작했을 때 검색어와 함께 호출될 클로저
+    // VC는 이 클로저를 통해 검색 결과 화면으로 전환하는 로직을 실행
+    var onSearchTriggered: ((String) -> Void)?
+
+    // MARK: - Initializer
+    init() {
+        // TODO: - 최근 검색어 기능 추가하면 UseCase의존성 추가
+    }
+
+    // MARK: - Input from VC
+    // 사용자가 검색 버튼을 눌렀을 때 VC로부터 호출될 메서드
+    func search(with searchText: String) {
+        onSearchTriggered?(searchText)
+    }
+}


### PR DESCRIPTION
<!-- 제목은 "OO을 해서 OO가 됩니다.", "OO화면의 UI를 구현합니다." 로 올려주세요 -->

# 개요
<!-- 개요는 와이어프레임이나, 이슈등을 사용하여 작업의 시작점을 알려줍니다. -->
- #5 
- 사용자가 상품을 검색하는 첫 관문인 검색화면(Search Scene)을 구현합니다.
- 검색 결과 화면 및 상세 화면의 내비게이션 바 스타일을 함께 수정하여 앱 전체의 검색 및 화면 이동 경험에 대한 일관성을 확보합니다.

# 작업 내용
<!-- 작업 내용에는 "무엇"은 간단하게 적고, 왜 이렇게 작성했는지 위주로 적습니다. -->
<!-- UI 구현의 경우 가능한 스크린샷을 포함합니다. -->

<img width="468" height="887" alt="스크린샷 2025-08-13 23 39 11" src="https://github.com/user-attachments/assets/85338087-4c48-4c70-9bd5-c42245316b1b" />

<img width="468" height="887" alt="스크린샷 2025-08-13 23 39 31" src="https://github.com/user-attachments/assets/95634690-6473-4333-897e-4fe79ceaa49f" />

<img width="468" height="887" alt="스크린샷 2025-08-13 23 39 37" src="https://github.com/user-attachments/assets/ec6fc590-643c-47d6-adf6-43aaeb51cab6" />

- SearchScene 구현
  - `SearchViewModel`: 사용자가 검색을 시작했다는 신호를 전달하는 역할만 하는 간단한 ViewModel을 구현했습니다.
  - `SearchViewController`
    - `UISearchController`를 `navigationItem`에 통합하여 iOS 기본 스타일의 검색 UI를 제공합니다.
    - 사용자가 검색을 실행하면 `DIContainer`를 통해 `ListViewController`를 생성하고 검색어를 전달하여 다음 화면으로 전환시킵니다.

- 내비게이션바 통일
  - `ListViewController`
    - `SearchViewController`와 동일한 `UISearchController`를 추가하여 사용자가 검색 결과 화면에서도 바로 이어서 다른 검색을 할 수 있도록 했습니다.
    - 재검색시, 새로운 `ListViewController`를 `push`하여 이전 검색 기록을 스택으로 관리하고 뒤로가기로 돌아올 수 있도록 UX를 개선했습니다.


# 기타
<!-- 기타 얘기할 사항이 있으면 얘기합니다. -->
- 현재 `SearchViewController`에는 최근 검색어 기능이 구현되어있지 않습니다.
- 앱의 시작점을 `SearchViewController`로 설정하여 테스트를 진행했습니다.
