### PR TITLE
[Feat]  최근 검색어 기능을 구현하여 사용자 편의성을 개선합니다.

### DIFF
--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		BC88BC5C2E4DBF1700F4B556 /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC5B2E4DBF1300F4B556 /* FilterViewController.swift */; };
 		BC88BC6A2E4DEF0300F4B556 /* RecentKeywordRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC692E4DEEFB00F4B556 /* RecentKeywordRepositoryProtocol.swift */; };
 		BC88BC6C2E4DEFBA00F4B556 /* RecentKeywordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */; };
+		BC88BC6E2E4DF0C200F4B556 /* DefaultRecentKeywordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +103,7 @@
 		BC88BC5B2E4DBF1300F4B556 /* FilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
 		BC88BC692E4DEEFB00F4B556 /* RecentKeywordRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordRepositoryProtocol.swift; sourceTree = "<group>"; };
 		BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordUseCase.swift; sourceTree = "<group>"; };
+		BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRecentKeywordRepository.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -346,6 +348,7 @@
 		BC7342DF2E4AF9CF00A24ADE /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */,
 				BC7343242E4C120300A24ADE /* MockProductRepository.swift */,
 			);
 			path = Repository;
@@ -577,6 +580,7 @@
 				BC7342FD2E4B56C800A24ADE /* ProductListResponseDTO.swift in Sources */,
 				BC7342EC2E4B4D4600A24ADE /* SearchProductsUseCase.swift in Sources */,
 				BC7342FF2E4B587400A24ADE /* ProductDetailDTO.swift in Sources */,
+				BC88BC6E2E4DF0C200F4B556 /* DefaultRecentKeywordRepository.swift in Sources */,
 				BC7343152E4B7B6A00A24ADE /* APIConstant.swift in Sources */,
 				BC88BC172E4C979300F4B556 /* ListViewModel.swift in Sources */,
 				BC7343082E4B62F500A24ADE /* NetworkService.swift in Sources */,

--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		BC88BC562E4DB3BF00F4B556 /* SortViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC552E4DB3B800F4B556 /* SortViewController.swift */; };
 		BC88BC582E4DBD9600F4B556 /* FilterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC572E4DBD9100F4B556 /* FilterViewModel.swift */; };
 		BC88BC5C2E4DBF1700F4B556 /* FilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC5B2E4DBF1300F4B556 /* FilterViewController.swift */; };
+		BC88BC6A2E4DEF0300F4B556 /* RecentKeywordRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC692E4DEEFB00F4B556 /* RecentKeywordRepositoryProtocol.swift */; };
+		BC88BC6C2E4DEFBA00F4B556 /* RecentKeywordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -98,6 +100,8 @@
 		BC88BC552E4DB3B800F4B556 /* SortViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SortViewController.swift; sourceTree = "<group>"; };
 		BC88BC572E4DBD9100F4B556 /* FilterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewModel.swift; sourceTree = "<group>"; };
 		BC88BC5B2E4DBF1300F4B556 /* FilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterViewController.swift; sourceTree = "<group>"; };
+		BC88BC692E4DEEFB00F4B556 /* RecentKeywordRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordRepositoryProtocol.swift; sourceTree = "<group>"; };
+		BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordUseCase.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -312,6 +316,7 @@
 		BC7342DC2E4AF9AE00A24ADE /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */,
 				BC7342ED2E4B4D4F00A24ADE /* GetProductDetailUseCase.swift */,
 				BC7342EB2E4B4D3200A24ADE /* SearchProductsUseCase.swift */,
 			);
@@ -321,6 +326,7 @@
 		BC7342DD2E4AF9B700A24ADE /* RepositoryProtocol */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC692E4DEEFB00F4B556 /* RecentKeywordRepositoryProtocol.swift */,
 				BC7342E92E4B478300A24ADE /* ProductRepositoryProtocol.swift */,
 			);
 			path = RepositoryProtocol;
@@ -555,6 +561,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BC7342E62E4B428000A24ADE /* NutritionInfo.swift in Sources */,
+				BC88BC6A2E4DEF0300F4B556 /* RecentKeywordRepositoryProtocol.swift in Sources */,
 				BC73430A2E4B635400A24ADE /* NetworkError.swift in Sources */,
 				BC7342EE2E4B4D5600A24ADE /* GetProductDetailUseCase.swift in Sources */,
 				BC7342E82E4B428800A24ADE /* ShopLink.swift in Sources */,
@@ -585,6 +592,7 @@
 				BC88BC562E4DB3BF00F4B556 /* SortViewController.swift in Sources */,
 				BC7342C02E4AE5EF00A24ADE /* ViewController.swift in Sources */,
 				BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */,
+				BC88BC6C2E4DEFBA00F4B556 /* RecentKeywordUseCase.swift in Sources */,
 				BC88BC2B2E4CC73B00F4B556 /* SearchViewModel.swift in Sources */,
 				BC88BC1D2E4C9A7700F4B556 /* ListViewController.swift in Sources */,
 				BC7342C12E4AE5EF00A24ADE /* AppDelegate.swift in Sources */,

--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		BC88BC6A2E4DEF0300F4B556 /* RecentKeywordRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC692E4DEEFB00F4B556 /* RecentKeywordRepositoryProtocol.swift */; };
 		BC88BC6C2E4DEFBA00F4B556 /* RecentKeywordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */; };
 		BC88BC6E2E4DF0C200F4B556 /* DefaultRecentKeywordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */; };
+		BC88BC702E4DF3A100F4B556 /* RecentKeywordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6F2E4DF39500F4B556 /* RecentKeywordCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +105,7 @@
 		BC88BC692E4DEEFB00F4B556 /* RecentKeywordRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordRepositoryProtocol.swift; sourceTree = "<group>"; };
 		BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordUseCase.swift; sourceTree = "<group>"; };
 		BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRecentKeywordRepository.swift; sourceTree = "<group>"; };
+		BC88BC6F2E4DF39500F4B556 /* RecentKeywordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordCell.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -271,6 +273,7 @@
 		BC7342D72E4AF99200A24ADE /* View */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC6F2E4DF39500F4B556 /* RecentKeywordCell.swift */,
 				BC88BC2C2E4CC74F00F4B556 /* SearchViewController.swift */,
 			);
 			path = View;
@@ -565,6 +568,7 @@
 			files = (
 				BC7342E62E4B428000A24ADE /* NutritionInfo.swift in Sources */,
 				BC88BC6A2E4DEF0300F4B556 /* RecentKeywordRepositoryProtocol.swift in Sources */,
+				BC88BC702E4DF3A100F4B556 /* RecentKeywordCell.swift in Sources */,
 				BC73430A2E4B635400A24ADE /* NetworkError.swift in Sources */,
 				BC7342EE2E4B4D5600A24ADE /* GetProductDetailUseCase.swift in Sources */,
 				BC7342E82E4B428800A24ADE /* ShopLink.swift in Sources */,

--- a/CaloLink/Source/Application/DIContainer.swift
+++ b/CaloLink/Source/Application/DIContainer.swift
@@ -18,10 +18,13 @@ final class DIContainer {
     // Repositories: 데이터 저장소도 하나만 존재
     lazy var productRepository: ProductRepositoryProtocol = MockProductRepository()
 //    lazy var productRepository: ProductRepositoryProtocol = DefaultProductRepository(networkService: networkService)
+    lazy var recentKeywordRepository: RecentKeywordRepositoryProtocol = DefaultRecentKeywordRepository()
+
 
     // Use Cases: UseCase는 상태를 가지지 않으므로 하나만 만들어 재사용
     lazy var searchProductsUseCase: SearchProductsUseCaseProtocol = SearchProductsUseCase(productRepository: productRepository)
     lazy var getProductDetailUseCase: GetProductDetailUseCaseProtocol = GetProductDetailUseCase(productRepository: productRepository)
+    lazy var recentKeywordUseCase: RecentKeywordUseCaseProtocol = DefaultRecentKeywordUseCase(repository: recentKeywordRepository)
 
     // MARK: - 조립 라인 (Factory Methods)
     // MARK: - 메인 Scene
@@ -42,8 +45,7 @@ final class DIContainer {
     // MARK: - 검색 Scene
     // SearchViewModel을 생성하는 팩토리 메서드
     func makeSearchViewModel() -> SearchViewModel {
-        // 지금은 UseCase 의존성이 없으므로 그냥 생성만
-        return SearchViewModel()
+        return SearchViewModel(recentKeywordUseCase: recentKeywordUseCase)
     }
 
     // SearchViewController를 생성하는 팩토리 메서드

--- a/CaloLink/Source/Application/DIContainer.swift
+++ b/CaloLink/Source/Application/DIContainer.swift
@@ -12,17 +12,19 @@ import Foundation
 final class DIContainer {
     // MARK: - 부품 창고 (Singleton Instances)
 
-    // Services: 네트워크 통신 엔진은 앱 전체에서 하나만 존재
+    // MARK: - Services: 네트워크 통신 엔진은 앱 전체에서 하나만 존재
     lazy var networkService: NetworkServiceProtocol = DefaultNetworkService()
 
-    // Repositories: 데이터 저장소도 하나만 존재
+    // MARK: - Repositories: 데이터 저장소도 하나만 존재
     lazy var productRepository: ProductRepositoryProtocol = MockProductRepository()
 //    lazy var productRepository: ProductRepositoryProtocol = DefaultProductRepository(networkService: networkService)
     lazy var recentKeywordRepository: RecentKeywordRepositoryProtocol = DefaultRecentKeywordRepository()
 
-
-    // Use Cases: UseCase는 상태를 가지지 않으므로 하나만 만들어 재사용
-    lazy var searchProductsUseCase: SearchProductsUseCaseProtocol = SearchProductsUseCase(productRepository: productRepository)
+    // MARK: - Use Cases: UseCase는 상태를 가지지 않으므로 하나만 만들어 재사용
+    lazy var searchProductsUseCase: SearchProductsUseCaseProtocol = SearchProductsUseCase(
+        productRepository: productRepository,
+        recentKeywordRepository: recentKeywordRepository
+    )
     lazy var getProductDetailUseCase: GetProductDetailUseCaseProtocol = GetProductDetailUseCase(productRepository: productRepository)
     lazy var recentKeywordUseCase: RecentKeywordUseCaseProtocol = DefaultRecentKeywordUseCase(repository: recentKeywordRepository)
 

--- a/CaloLink/Source/Data/Repository/DefaultRecentKeywordRepository.swift
+++ b/CaloLink/Source/Data/Repository/DefaultRecentKeywordRepository.swift
@@ -1,0 +1,56 @@
+//
+//  DefaultRecentKeywordRepository.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/14/25.
+//
+
+import Foundation
+
+// MARK: - DefaultRecentKeywordRepository
+// UserDefaults를 사용하여 최근 검색어를 로컬에 저장하고 관리하는 Repository 구현체
+final class DefaultRecentKeywordRepository: RecentKeywordRepositoryProtocol {
+    // UserDefaults에 데이터를 저장할 때 사용할 고유 키
+    private let userDefaultsKey = "RecentKeywords"
+    // 저장할 최대 검색어 개수
+    private let maxKeywordsCount = 10
+
+    func fetchKeywords() -> [String] {
+        // UserDefaults에서 문자열 배열을 가져옴
+        // 저장된 값이 없으면 빈 배열을 반환
+        return UserDefaults.standard.stringArray(forKey: userDefaultsKey) ?? []
+    }
+
+    func saveKeyword(_ keyword: String) {
+        var keywords = fetchKeywords()
+
+        // 이미 저장된 검색어라면 기존 것을 삭제
+        keywords.removeAll { $0 == keyword }
+
+        // 새로운 검색어를 맨 앞에 추가
+        keywords.insert(keyword, at: 0)
+
+        // 최대 개수(10개)를 초과하면 가장 오래된 검색어를 삭제
+        if keywords.count > maxKeywordsCount {
+            keywords = Array(keywords.prefix(maxKeywordsCount))
+        }
+
+        // 최종 배열을 UserDefaults에 저장
+        UserDefaults.standard.set(keywords, forKey: userDefaultsKey)
+    }
+
+    func deleteKeyword(at index: Int) {
+        var keywords = fetchKeywords()
+
+        // 해당 인덱스의 검색어가 유효한지 확인 후 삭제
+        guard keywords.indices.contains(index) else { return }
+        keywords.remove(at: index)
+
+        UserDefaults.standard.set(keywords, forKey: userDefaultsKey)
+    }
+
+    func deleteAllKeywords() {
+        // 해당 키의 모든 데이터를 삭제
+        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+    }
+}

--- a/CaloLink/Source/Domain/RepositoryProtocol/RecentKeywordRepositoryProtocol.swift
+++ b/CaloLink/Source/Domain/RepositoryProtocol/RecentKeywordRepositoryProtocol.swift
@@ -1,0 +1,22 @@
+//
+//  RecentKeywordRepositoryProtocol.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/14/25.
+//
+
+// MARK: - 최근 검색어 데이터에 접근하기 위한 저장소의 인터페이스(규칙)
+// 데이터의 출처가 로컬(UserDefaults)이므로 비동기 처리가 필요 없어 동기적으로 작동
+protocol RecentKeywordRepositoryProtocol {
+    // 저장된 모든 최근 검색어를 가져오기
+    func fetchKeywords() -> [String]
+
+    // 새로운 검색어를 저장하기
+    func saveKeyword(_ keyword: String)
+
+    // 특정 위치(index)의 검색어를 삭제하기
+    func deleteKeyword(at index: Int)
+
+    // 모든 검색어를 삭제하기
+    func deleteAllKeywords()
+}

--- a/CaloLink/Source/Domain/UseCase/RecentKeywordUseCase.swift
+++ b/CaloLink/Source/Domain/UseCase/RecentKeywordUseCase.swift
@@ -1,0 +1,39 @@
+//
+//  RecentKeywordUseCase.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/14/25.
+//
+
+// MARK: - 최근 검색어 관련 비즈니스 로직을 정의하는 프로토콜
+protocol RecentKeywordUseCaseProtocol {
+    func fetchKeywords() -> [String]
+    func saveKeyword(_ keyword: String)
+    func deleteKeyword(at index: Int)
+    func deleteAllKeywords()
+}
+
+// RecentKeywordUseCaseProtocol의 기본 구현체
+final class DefaultRecentKeywordUseCase: RecentKeywordUseCaseProtocol {
+    private let repository: RecentKeywordRepositoryProtocol
+
+    init(repository: RecentKeywordRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    func fetchKeywords() -> [String] {
+        return repository.fetchKeywords()
+    }
+
+    func saveKeyword(_ keyword: String) {
+        repository.saveKeyword(keyword)
+    }
+
+    func deleteKeyword(at index: Int) {
+        repository.deleteKeyword(at: index)
+    }
+
+    func deleteAllKeywords() {
+        repository.deleteAllKeywords()
+    }
+}

--- a/CaloLink/Source/Domain/UseCase/SearchProductsUseCase.swift
+++ b/CaloLink/Source/Domain/UseCase/SearchProductsUseCase.swift
@@ -18,10 +18,15 @@ protocol SearchProductsUseCaseProtocol {
 final class SearchProductsUseCase: SearchProductsUseCaseProtocol {
     // 작업을 전달할 레포지토리 선언
     private let productRepository: ProductRepositoryProtocol
+    private let recentKeywordRepository: RecentKeywordRepositoryProtocol
 
     // 의존성 주입(DI)을 통해 Repository를 받음
-    init(productRepository: ProductRepositoryProtocol) {
+    init(
+        productRepository: ProductRepositoryProtocol,
+        recentKeywordRepository: RecentKeywordRepositoryProtocol
+    ) {
         self.productRepository = productRepository
+        self.recentKeywordRepository = recentKeywordRepository
     }
 
     // UseCase의 핵심 로직을 수행하는 메서드
@@ -29,8 +34,12 @@ final class SearchProductsUseCase: SearchProductsUseCaseProtocol {
         query: SearchQuery,
         completion: @escaping (Result<[Product], Error>) -> Void
     ) {
-        // TODO: - 실제 구현은 Data Layer가 완성된 후 작성
-        // 지금은 Repository에 작업을 그대로 전달하는 역할만 함
+        // 검색을 실행하기전, 검색어를 로컬에 저장
+        if !query.searchText.isEmpty {
+            recentKeywordRepository.saveKeyword(query.searchText)
+        }
+
+        // Repository에 작업을 그대로 전달
         productRepository.fetchProducts(query: query, completion: completion)
     }
 }

--- a/CaloLink/Source/Presentation/SearchScene/View/RecentKeywordCell.swift
+++ b/CaloLink/Source/Presentation/SearchScene/View/RecentKeywordCell.swift
@@ -1,0 +1,81 @@
+//
+//  RecentKeywordCell.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/14/25.
+//
+
+import UIKit
+
+// MARK: - RecentKeywordCellDelegate
+// 셀 내부의 삭제 버튼 탭 이벤트를 ViewController에 전달하기 위한 프로토콜
+protocol RecentKeywordCellDelegate: AnyObject {
+    func recentKeywordCellDidTapDeleteButton(for cell: UITableViewCell)
+}
+
+// MARK: - RecentKeywordCell
+final class RecentKeywordCell: UITableViewCell {
+    static let identifier = "RecentKeywordCell"
+    weak var delegate: RecentKeywordCellDelegate?
+
+    // MARK: - UI Components
+    private let keywordLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .black
+        return label
+    }()
+
+    private lazy var deleteButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = .systemGray
+        button.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    // MARK: - Initializer
+    override init(
+        style: UITableViewCell.CellStyle,
+        reuseIdentifier: String?
+    ) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public Method
+    func configure(with keyword: String) {
+        keywordLabel.text = keyword
+    }
+
+    // MARK: - Private Action
+    @objc private func deleteButtonTapped() {
+        delegate?.recentKeywordCellDidTapDeleteButton(for: self)
+    }
+}
+
+// MARK: - UI Setup
+private extension RecentKeywordCell {
+    func setupUI() {
+        contentView.backgroundColor = .white
+        [keywordLabel, deleteButton].forEach {
+            contentView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        NSLayoutConstraint.activate([
+            keywordLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            keywordLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            keywordLabel.trailingAnchor.constraint(equalTo: deleteButton.leadingAnchor, constant: -12),
+
+            deleteButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            deleteButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            deleteButton.widthAnchor.constraint(equalToConstant: 24),
+            deleteButton.heightAnchor.constraint(equalToConstant: 24)
+        ])
+    }
+}

--- a/CaloLink/Source/Presentation/SearchScene/ViewModel/SearchViewModel.swift
+++ b/CaloLink/Source/Presentation/SearchScene/ViewModel/SearchViewModel.swift
@@ -9,19 +9,61 @@ import Foundation
 
 // MARK: - SearchViewModel
 final class SearchViewModel {
+    // MARK: - 프로퍼티
+    private let recentKeywordUseCase: RecentKeywordUseCaseProtocol
+
     // MARK: - Output to VC
     // 사용자가 검색을 시작했을 때 검색어와 함께 호출될 클로저
     // VC는 이 클로저를 통해 검색 결과 화면으로 전환하는 로직을 실행
     var onSearchTriggered: ((String) -> Void)?
 
+    // 최근 검색어 목록이 변경될 때마다 View에게 알리기 위한 클로저
+    var onKeywordsUpdate: (() -> Void)?
+
+    // View에 표시될 최근 검색어 목록
+    private(set) var recentKeywords: [String] = [] {
+        didSet {
+            // 배열이 변경되면 View에 알림
+            onKeywordsUpdate?()
+        }
+    }
+
     // MARK: - Initializer
-    init() {
-        // TODO: - 최근 검색어 기능 추가하면 UseCase의존성 추가
+    init(recentKeywordUseCase: RecentKeywordUseCaseProtocol) {
+        self.recentKeywordUseCase = recentKeywordUseCase
     }
 
     // MARK: - Input from VC
+
+    // View가 나타날 때 호출되어 최근 검색어를 불러옴
+    func viewDidLoad() {
+        loadKeywords()
+    }
+
     // 사용자가 검색 버튼을 눌렀을 때 VC로부터 호출될 메서드
     func search(with searchText: String) {
+        // 새로운 검색어 저장
+        recentKeywordUseCase.saveKeyword(searchText)
+        // 변경된 목록을 다시 불러옴
+        loadKeywords()
+        // 검색 결과 화면으로 이동하라는 신호를 보냄
         onSearchTriggered?(searchText)
+    }
+
+    // 특정 위치의 검색어를 삭제
+    func deleteKeyword(at index: Int) {
+        recentKeywordUseCase.deleteKeyword(at: index)
+        loadKeywords()
+    }
+
+    // 모든 검색어를 삭제
+    func deleteAllKeywords() {
+        recentKeywordUseCase.deleteAllKeywords()
+        loadKeywords()
+    }
+
+    // UseCase를 통해 저장된 최근 검색어를 불러와 프로퍼티를 업데이트
+    private func loadKeywords() {
+        self.recentKeywords = recentKeywordUseCase.fetchKeywords()
     }
 }


### PR DESCRIPTION
<!-- 제목은 "OO을 해서 OO가 됩니다.", "OO화면의 UI를 구현합니다." 로 올려주세요 -->

# 개요
<!-- 개요는 와이어프레임이나, 이슈등을 사용하여 작업의 시작점을 알려줍니다. -->
- 사용자가 이전에 검색했던 키워드를 다시 쉽게 사용할 수 있도록 최근 검색어 기능을 구현합니다.

# 작업 내용
<!-- 작업 내용에는 "무엇"은 간단하게 적고, 왜 이렇게 작성했는지 위주로 적습니다. -->
<!-- UI 구현의 경우 가능한 스크린샷을 포함합니다. -->

<img width="468" height="887" alt="스크린샷 2025-08-14 20 07 50" src="https://github.com/user-attachments/assets/e6da317a-3a45-4375-99c7-bdeb9a8db43a" />

- Domain, Data Layer
  - `RecentKeywordRepositoryProtocol` 및 `UserDefaults`를 사용하는 `DefaultRecentKeywordRepository`를 구현했습니다.
  - 최근 검색어는 서버 동기화가 필요 없는 사용자 개인의 데이터이므로 속도가 빠르고 오프라인을 지원하는 로컬 저장소(`UserDefaults`)를 데이터 출처로 선택했습니다.

- UseCase 로직 통합
  - 최근 검색어를 관리하는 `RecentKeywordUseCase`를 구현했습니다.
  - `SearchProductsUseCase`가 상품 목록을 검색하기 전에 검색어를 저장하는 책임까지 함께 갖도록 로직을 통합했습니다.
  - 이렇게하면 `SearchViewController`에서 검색하든 `ListViewController`에서 재검색하든 "검색"이라는 행동이 일어나는 모든 곳에서 일관되게 검색어가 저장되도록 보장할 수 있습니다.

- SearchScene UI 및 로직 구현
  - `SearchViewModel`이 `RecentKeywordUseCase`를 사용하도록 수정하여 최근검색어 목록을 불러오고, 저장/삭제하는 모든 상태 관리를 책임지도록 했습니다.
  - `SearchViewController`의 기존 안내 문구를 `UITableView`로 교체하여 ViewModel이 전달하는 최근 검색어 목록을 사용자에게 보여줍니다.
  - 사용자가 최근 검색어를 탭하면 바로 검색이 실행되고 개별/전체 삭제가 가능하도록 UI와 로직을 모두 연결했습니다.