### PR TITLE
[Feat] DefaultProductRepository를 구현하여 실제 서버 통신 로직을 완성합니다.

### DIFF
--- a/CaloLink/CaloLink.xcodeproj/project.pbxproj
+++ b/CaloLink/CaloLink.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		BC88BC6C2E4DEFBA00F4B556 /* RecentKeywordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */; };
 		BC88BC6E2E4DF0C200F4B556 /* DefaultRecentKeywordRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */; };
 		BC88BC702E4DF3A100F4B556 /* RecentKeywordCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC6F2E4DF39500F4B556 /* RecentKeywordCell.swift */; };
+		BC88BC7E2E4E04AB00F4B556 /* DefaultProductRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC88BC7D2E4E04A500F4B556 /* DefaultProductRepository.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -106,6 +107,7 @@
 		BC88BC6B2E4DEFB700F4B556 /* RecentKeywordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordUseCase.swift; sourceTree = "<group>"; };
 		BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultRecentKeywordRepository.swift; sourceTree = "<group>"; };
 		BC88BC6F2E4DF39500F4B556 /* RecentKeywordCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordCell.swift; sourceTree = "<group>"; };
+		BC88BC7D2E4E04A500F4B556 /* DefaultProductRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductRepository.swift; sourceTree = "<group>"; };
 		BCFC37812E4A0385009A03D0 /* CaloLink.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CaloLink.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37972E4A0387009A03D0 /* CaloLinkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BCFC37A12E4A0387009A03D0 /* CaloLinkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CaloLinkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -351,6 +353,7 @@
 		BC7342DF2E4AF9CF00A24ADE /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				BC88BC7D2E4E04A500F4B556 /* DefaultProductRepository.swift */,
 				BC88BC6D2E4DF0C100F4B556 /* DefaultRecentKeywordRepository.swift */,
 				BC7343242E4C120300A24ADE /* MockProductRepository.swift */,
 			);
@@ -598,6 +601,7 @@
 				BC7343252E4C120C00A24ADE /* MockProductRepository.swift in Sources */,
 				BC88BC2D2E4CC75400F4B556 /* SearchViewController.swift in Sources */,
 				BC88BC562E4DB3BF00F4B556 /* SortViewController.swift in Sources */,
+				BC88BC7E2E4E04AB00F4B556 /* DefaultProductRepository.swift in Sources */,
 				BC7342C02E4AE5EF00A24ADE /* ViewController.swift in Sources */,
 				BC7343232E4C0CF400A24ADE /* DIContainer.swift in Sources */,
 				BC88BC6C2E4DEFBA00F4B556 /* RecentKeywordUseCase.swift in Sources */,

--- a/CaloLink/Source/Data/Repository/DefaultProductRepository.swift
+++ b/CaloLink/Source/Data/Repository/DefaultProductRepository.swift
@@ -1,0 +1,60 @@
+//
+//  DefaultProductRepository.swift
+//  CaloLink
+//
+//  Created by 김성훈 on 8/14/25.
+//
+
+import Foundation
+
+// MARK: - DefaultProductRepository
+// 실제 네트워크 통신을 통해 상품 데이터를 가져오는 Repository 구현체
+final class DefaultProductRepository: ProductRepositoryProtocol {
+    private let networkService: NetworkServiceProtocol
+
+    // 의존성 주입(DI)을 통해 네트워크 통신 엔진을 받음
+    init(networkService: NetworkServiceProtocol) {
+        self.networkService = networkService
+    }
+
+    // MARK: - 상품 목록 가져오기
+    func fetchProducts(
+        query: SearchQuery,
+        completion: @escaping (Result<[Product], Error>) -> Void
+    ) {
+        // "상품 검색" API 명세서(Endpoint)를 만듦
+        let endpoint = ProductAPI.Search(query: query)
+
+        // 네트워크 엔진에 API 요청을 보냄
+        networkService.request(endpoint: endpoint) { result in
+            switch result {
+            case .success(let productListDTO):
+                // 성공시 DTO를 Domain Entity로 변환하여 전달
+                let products = productListDTO.products.map { $0.toDomain() }
+                completion(.success(products))
+                
+            case .failure(let error):
+                // 실패시 받은 에러를 그대로 전달
+                completion(.failure(error))
+            }
+        }
+    }
+
+    // MARK: - 상품 상세 정보 가져오기
+    func fetchProductDetail(
+        productId: String,
+        completion: @escaping (Result<ProductDetail, Error>) -> Void
+    ) {
+        // "상품 상세 정보" API 명세서를 만들어 요청
+        let endpoint = ProductAPI.Detail(productId: productId)
+
+        networkService.request(endpoint: endpoint) { result in
+            switch result {
+            case .success(let productDetailDTO):
+                completion(.success(productDetailDTO.toDomain()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/CaloLink/Source/Domain/UseCase/GetProductDetailUseCase.swift
+++ b/CaloLink/Source/Domain/UseCase/GetProductDetailUseCase.swift
@@ -29,8 +29,7 @@ final class GetProductDetailUseCase: GetProductDetailUseCaseProtocol {
         productId: String,
         completion: @escaping (Result<ProductDetail, Error>) -> Void
     ) {
-        // TODO: - 실제 구현은 Data Layer가 완성된 후 작성
-        // 지금은 Repository에 작업을 그대로 전달하는 역할만 함
+        // Repository에 작업을 그대로 전달
         productRepository.fetchProductDetail(productId: productId, completion: completion)
     }
 }


### PR DESCRIPTION
<!-- 제목은 "OO을 해서 OO가 됩니다.", "OO화면의 UI를 구현합니다." 로 올려주세요 -->

# 개요
<!-- 개요는 와이어프레임이나, 이슈등을 사용하여 작업의 시작점을 알려줍니다. -->
- 이전에 설계한 `NetworkService`와 DTO를 사용하여 Domain Layer의 `ProductRepositoryProtocol`을 준수하는 실제 Repository 구현체인 `DefaultProductRepository`를 완성합니다.
- 이 작업을 통해 앱이 Mock이 아닌 실제 서버와 통신할 수 있는 모든 준비를 마칩니다.

# 작업 내용
<!-- 작업 내용에는 "무엇"은 간단하게 적고, 왜 이렇게 작성했는지 위주로 적습니다. -->
<!-- UI 구현의 경우 가능한 스크린샷을 포함합니다. -->
- `DefaultProductRepository`구현
  - `NetworkService`에 대한 의존성을 주입받아 실제 네트워크 통신을 위임하도록 설계했습니다.
  - `fetchProducts(query:)`와 `fetchProductDetail(productId:)`메서드 내부에서 각각 `ProductAPI.Search`와 `ProductAPI.Detail` EndPoint를 생성하여 `NetworkService`에 요청을 보냅니다.
  - Repository는 어떤 API를 호출할지만 결정하고 실제 통신 로직은 `NetworkService`가 담당하도록 하여 역할을 명확히 분리했습니다.
  - 네트워크 통신 성공시 응답받은 DTO를 `toDomain()` 메서드를 통해 Domain의 Entity로 변환하는 과정을 포함했습니다.

# 기타
<!-- 기타 얘기할 사항이 있으면 얘기합니다. -->
- 이번 PR로 인해 Data Layer의 구현이 완료되었습니다.
- 이제 `DIContainer`에서 `MockProductRepository`대신 `DefaultProductRepository`를 주입하도록 변경하면 앱 전체가 실제 서버 데이터를 사용하여 통신하게 됩니다.